### PR TITLE
Add support for `{{extraAttributes}}` on child nodes

### DIFF
--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -214,11 +214,14 @@ module.exports = function (config, req, res, context) {
             return;
         }
 
-        if (!context.data.root.extraAttributes) {
-            return;
+        if (!context.data || !context.data.root.extraAttributes){
+            // check for context-level `extraAttributes` before exiting
+            if (!context.extraAttributes){
+                return;
+            }
         }
 
-        extraAttributesData = context.data.root.extraAttributes;
+        extraAttributesData = context.extraAttributes || context.data.root.extraAttributes;
 
         for (var key in extraAttributesData) {
             extraAttributes += ' ' + key + '="' + extraAttributesData[key] + '"';


### PR DESCRIPTION
It would be handy to be able to use the `{{extraAttributes}}` helper within array objects. This would allow us to reduce the amount of nested template calls for modules. For example, in the JSON data we could define those attributes on objects within an Array like this:

[/styleguide/foo/bar.json]

``` json
{
    "_template": "/assets/foo/bar",
    "biz": "bam",
    "listOfThings": [
        {
            "extraAttributes": {
                "foo": "bar"
            }
        }
    ]
}
```

and then later in the template, call the helper and pass the context:
[/assets/foo/bar.hbs]

``` handlebars
{{#each listOfThings as |item|}}
    <div {{extraAttributes item}}>Hello</div>
{{/each}}
```

..which would yield:

``` html
<div foo="bar">Hello</div>
```
