### PR TITLE
Makes view classes have default interface methods that return null.

### DIFF
--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinition.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinition.java
@@ -166,7 +166,10 @@ abstract class TemplateFieldDefinition {
             }).collect(Collectors.joining(""));
         }
 
-        return methodJavaDoc + indent(indent) + getJavaFieldType(imports) + " " + getJavaInterfaceMethodName() + "();";
+        return methodJavaDoc
+                + indent(indent) + "default " + getJavaFieldType(imports) + " " + getJavaInterfaceMethodName() + "() {\n"
+                + indent(indent + 1) + "return null;\n"
+                + indent(indent) + "}";
     }
 
     public String getInterfaceBuilderFieldDeclarationSource(int indent, Set<String> imports) {


### PR DESCRIPTION
Prevents gratuitous compilation errors caused by JSON data file changes on fields that aren't actually used.
