### PR TITLE
Allow extending `_dataUrl`s data with current context data

### DIFF
--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -48,7 +48,8 @@ function resolveDataUrlPaths(data, currentDataPath, library) {
             var originalDataPath = currentDataPath;
             currentDataPath = dataPath;
 
-            this.update(JSON.parse(fs.readFileSync(dataPath, 'utf8')));
+            // extend the incoming data from `dataUrl` with this node's data, then update the node
+            this.update(_.extend({ }, JSON.parse(fs.readFileSync(dataPath, 'utf8')), this.node));
 
             currentDataPath = originalDataPath;
         }


### PR DESCRIPTION
When using `_dataUrl` to embed JSON data into your data files there's currently no support for overriding/extending the embedded JSON. This code supports that feature. For example:

(foo.json)

```
{
    "_template":"/templates/t1",
    "a":"Ham",
    "b":"burger"
}
```

And you want to embed that into a JSON like this but override the `b` field...

(bar.json)

```
{
    "_template":"/templates/t2",
    "d":{
         "_dataUrl": "/data/foo.json",
         "b":"Sandwich"
    }
}
```

Would yield:

```
{
    "_template":"/templates/t2",
    "d":{
         "_template":"/templates/t1",
         "a":"Ham",
         "b":"Sandwich"
    }
}
```
