### PR TITLE
Removes automatic Handlebars processing on Array.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -16,16 +16,6 @@ var Library = require('./library');
 var logger = require('./logger');
 var renderPage = require('./render-page');
 
-Array.prototype.toHTML = function () {
-    var html = '';
-
-    this.forEach(function (item) {
-        html += item.toHTML ? item.toHTML() : item.toString();
-    });
-
-    return html;
-};
-
 var defaults = {
     'project-path': '.',
     'styleguide-path': 'styleguide',


### PR DESCRIPTION
Java implementation doesn't support this, so we should take it out to reduce confusion on something working within Styleguide but not on the actual site.
