### PR TITLE
Fixes Lists to support mixed types of String and Object.

### DIFF
--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinition.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinition.java
@@ -31,10 +31,7 @@ abstract class TemplateFieldDefinition {
                 || valueTypes.size() == 2 && valueTypes.contains(JsonObjectType.TEMPLATE_OBJECT) && valueTypes.contains(JsonObjectType.STRING)) {
 
             if (valueTypes.size() == 2) {
-
-                // special case that we allow, but just log it as a warning.
-                CliLogger.getLogger().yellow("WARN: (", parentTemplate, " - ", name, ") has multiple value types ", valueTypes, ".");
-
+                // We allow Strings and Objects to co-exist and just treat them as if it is Object
                 effectiveValueType = JsonObjectType.TEMPLATE_OBJECT;
 
             } else {

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinitionList.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinitionList.java
@@ -37,11 +37,21 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
         if (!listValueTypes.isEmpty()) {
 
             if (listValueTypes.size() > 1) {
-                throw new IllegalArgumentException("ERROR: (" + this.parentTemplate + " - " + this.name
-                        + ") List can only have one item value type but found [" + listValueTypes + "]!");
-            }
 
-            effectiveListValueType = listValueTypes.iterator().next();
+                if (listValueTypes.size() == 2
+                        && listValueTypes.contains(JsonObjectType.TEMPLATE_OBJECT) && listValueTypes.contains(JsonObjectType.STRING)) {
+
+                    // We allow Strings and Objects to co-exist and just treat them as if it is Object
+                    effectiveListValueType = JsonObjectType.TEMPLATE_OBJECT;
+
+                } else {
+                    throw new IllegalArgumentException("ERROR: (" + this.parentTemplate + " - " + this.name
+                            + ") List can only have one item value type but found [" + listValueTypes + "]!");
+                }
+
+            } else {
+                effectiveListValueType = listValueTypes.iterator().next();
+            }
 
             if (effectiveListValueType == JsonObjectType.BOOLEAN) {
                 listItemJavaType = "Boolean";


### PR DESCRIPTION
Removes warning on fields in general when both String and Object is found. We treat mixes of String and Object as if it is just Object.
