### PR TITLE
Fix the request URL processing to skip URLs that do not have the libr…

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -132,7 +132,14 @@ module.exports = function (config) {
         context.library = library;
 
         // Request URL (e.g. /foo/bar) to file path (e.g. \foo\bar in Windows).
-        var requestedUrl = context.requestedUrl = req.path.slice(library.urlPrefix.length);
+        var requestedUrl = req.path;
+        // Is this request pathed under the library prefix?
+        if (requestedUrl.indexOf(library.urlPrefix) > -1){
+            // strip the library path off
+            requestedUrl = req.path.slice(library.urlPrefix.length);
+        }
+
+        context.requestedUrl = requestedUrl;
         var requestedPath = context.requestedPath = path.join.apply(path, requestedUrl.split('/'));
 
         // Styleguide names based on the request URL.


### PR DESCRIPTION
…ary path within them.

This comes in handy when you want to allow Express to route urls like
`/foo/bar.css`
