### PR TITLE
Add ability to pass an examples' `_config.json` data to main template.

### DIFF
--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -9,6 +9,10 @@ function read(context, filePath) {
 module.exports = function (config, context, templatePath) {
     handlebars.registerPartial('layout', read(context, '/layout.hbs'));
 
+    if (config.example){
+        context.example = config.example;
+    }
+
     var template = handlebars.compile(read(context, templatePath), {
         preventIndent: true
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -345,6 +345,13 @@ module.exports = function (config) {
                 } else {
                     files.push(f);
                 }
+
+                if (fs.existsSync(examplePath + '/_config.json')) {
+                    config.example = JSON.parse(fs.readFileSync(examplePath + '/_config.json', 'utf-8'));
+                }
+                else {
+                    config.example = null;
+                }
             }
         });
 

--- a/styleguide/main.hbs
+++ b/styleguide/main.hbs
@@ -15,6 +15,13 @@
                         log: false,
                         heightCalculationMethod: 'max',
                         autoResize: true,
+                        scrolling: true,
+                        {{#if example.exampleMinHeight}}
+                          minHeight: {{example.exampleMinHeight}},
+                        {{/if}}
+                        {{#if example.exampleMaxHeight}}
+                          maxHeight: {{example.exampleMaxHeight}},
+                        {{/if}}
                         initCallback: function(iframe) {
                             $(iframe).contents().find('html', 'body').css('height', 'auto');
                         }


### PR DESCRIPTION
This feature allows the developer to control the height of the example `<iframe>` on a per-example basis.  You would define a `_config.json` file in the example directory you want to control with the following configurations:

(contents of `_config.json`)

```
{
    "exampleMinHeight": 400,
    "exampleMaxHeight": 800
}
```
