### PR TITLE
Fix empty string element values in json

### DIFF
--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -320,7 +320,7 @@ module.exports = function (config, req, res, context) {
         if (elementOptions.hash.noWith) {
             value = elementOptions.fn(this, fnOptions);
 
-        } else if (value) {
+        } else if (value !== null && typeof value !== 'undefined') {
             value = elementOptions.fn(value, fnOptions);
 
         } else {


### PR DESCRIPTION
This fix will render elements that have an empty string value in the source json, like so:
#### NameBlock.json:

```
"NameBlock": {
    "_template": "elements/NameBlock",
    "firstName": ""
}
```
#### NameBlock.hbs:

```
{{#defineBlock "NameBlock"}}
    {{#defineElement "firstName"}}
        <input type="text" name="firstName" class="{{elementName}}" value="{{this}}">
    {{/defineElement}}

    <fieldset class="{{blockName}}">
        {{#defaultBlockBody}}
            {{element "firstName"}}
        {{/defaultBlockBody}}
    </fieldset>
{{/defineBlock}}
```
#### Output:

```
<fieldset class="NameBlock">
    <input type="text" name="firstName" class="NameBlock-firstName" value="">
</fieldset>
```

Elements that are `null` or that do not exist in the json will continue to not be rendered.
