### PR TITLE
Modified and added additional APIs for dealing with Collections.

### DIFF
--- a/viewgenerator/src/main/java/com/psddev/styleguide/JsonDataFile.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/JsonDataFile.java
@@ -214,7 +214,7 @@ class JsonDataFile {
                     }
                 });
 
-                return new JsonTemplateObject(template, fields, fieldNotes, templateNotes);
+                return new JsonTemplateObject(StringUtils.ensureStart(template, "/"), fields, fieldNotes, templateNotes);
 
             } else {
                 throw new MissingTemplateException(this, map);

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinition.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinition.java
@@ -147,22 +147,25 @@ class TemplateDefinition {
         builder.append("@HandlebarsTemplate(\"").append(StringUtils.removeStart(name, "/")).append("\")\n");
         builder.append("public interface ").append(getJavaClassName()).append(" {\n");
 
-        boolean printedAnyStaticStringVariableDeclaration = false;
         for (TemplateFieldDefinition fieldDef : fields) {
 
             if (fieldDef instanceof TemplateFieldDefinitionList
                     || fieldDef instanceof TemplateFieldDefinitionObject
                     || fieldDef instanceof TemplateFieldDefinitionString) {
 
-                String declaration = fieldDef.getInterfaceStaticStringVariableDeclaration(1);
-                if (declaration != null) {
-                    builder.append("\n").append(declaration);
-                    printedAnyStaticStringVariableDeclaration = true;
-                }
+                String declaration = fieldDef.getInterfaceStaticStringVariableDeclaration(1, "_ELEMENT");
+                builder.append("\n").append(declaration).append("\n");
             }
         }
-        if (printedAnyStaticStringVariableDeclaration) {
-            builder.append("\n");
+        for (TemplateFieldDefinition fieldDef : fields) {
+
+            if (fieldDef instanceof TemplateFieldDefinitionList
+                    || fieldDef instanceof TemplateFieldDefinitionObject
+                    || fieldDef instanceof TemplateFieldDefinitionString) {
+
+                String declaration = fieldDef.getInterfaceStaticStringVariableDeclarationDeprecated(1, "_TYPE", "_ELEMENT");
+                builder.append("\n").append(declaration).append("\n");
+            }
         }
 
         for (TemplateFieldDefinition fieldDef : fields) {

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinition.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinition.java
@@ -171,7 +171,7 @@ abstract class TemplateFieldDefinition {
             String valueTypesJavaDocListPrefix;
 
             if (this instanceof TemplateFieldDefinitionList) {
-                valueTypesJavaDocListPrefix = "Typically a List of ";
+                valueTypesJavaDocListPrefix = "Typically a Collection of ";
             } else {
                 valueTypesJavaDocListPrefix = "Typically a ";
             }
@@ -184,7 +184,7 @@ abstract class TemplateFieldDefinition {
             methodJavaDoc = Arrays.stream(new String[] {
                     indent(indent) + "/**\n",
                     notesSource.toString(),
-                    indent(indent) + " * <p>" + valueTypesJavaDocListPrefix + valueTypesJavaDocList + "</p>.\n",
+                    indent(indent) + " * <p>" + valueTypesJavaDocListPrefix + valueTypesJavaDocList + ".</p>\n",
                     indent(indent) + " */\n"
             }).collect(Collectors.joining(""));
         }
@@ -220,7 +220,7 @@ abstract class TemplateFieldDefinition {
             String valueTypesJavaDocListPrefix;
 
             if (this instanceof TemplateFieldDefinitionList) {
-                valueTypesJavaDocListPrefix = "Typically a List of ";
+                valueTypesJavaDocListPrefix = "Typically a Collection of ";
             } else {
                 valueTypesJavaDocListPrefix = "Typically a ";
             }

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinition.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinition.java
@@ -195,12 +195,30 @@ abstract class TemplateFieldDefinition {
                 + indent(indent) + "}";
     }
 
-    public String getInterfaceStaticStringVariableDeclaration(int indent) {
+    public String getInterfaceStaticStringVariableDeclaration(int indent, String suffix) {
+        return getInterfaceStaticStringVariableDeclarationHelper(indent, suffix, false, null);
+    }
 
-        String varName = StringUtils.toUnderscored(name).toUpperCase() + "_TYPE";
+    public String getInterfaceStaticStringVariableDeclarationDeprecated(int indent, String suffix, String alternateSuffix) {
+        return getInterfaceStaticStringVariableDeclarationHelper(indent, suffix, true, alternateSuffix);
+    }
+
+    private String getInterfaceStaticStringVariableDeclarationHelper(int indent, String suffix, boolean isDeprecated, String alternateSuffix) {
+        String varName = StringUtils.toUnderscored(name).toUpperCase() + suffix;
         String varValue = name;
 
-        return indent(indent) + "static final String " + varName + " = \"" + varValue + "\";";
+        String declaration = "";
+
+        if (isDeprecated) {
+            String deprecatedVarName = StringUtils.toUnderscored(name).toUpperCase() + alternateSuffix;
+            declaration += indent(indent) + "/**\n";
+            declaration += indent(indent) + " * @deprecated Use {@link #" + deprecatedVarName + "} instead.\n";
+            declaration += indent(indent) + " */\n";
+            declaration += indent(indent) + "@Deprecated\n";
+        }
+        declaration += indent(indent) + "static final String " + varName + " = \"" + varValue + "\";";
+
+        return declaration;
     }
 
     public String getInterfaceBuilderFieldDeclarationSource(int indent, Set<String> imports) {

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinitionList.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinitionList.java
@@ -1,6 +1,7 @@
 package com.psddev.styleguide;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -65,7 +66,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
 
             } else if (effectiveListValueType == JsonObjectType.LIST) {
                 listItemJavaType = "?";
-                listItemTypes.add("java.util.List");
+                listItemTypes.add("java.util.Collection");
 
             } else if (effectiveListValueType == JsonObjectType.TEMPLATE_OBJECT) {
                 listItemJavaType = "?";
@@ -88,13 +89,13 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
 
     @Override
     public String getJavaFieldType(Set<String> imports) {
-        imports.add(List.class.getName());
-        return "List<" + listItemJavaType + ">";
+        imports.add(Collection.class.getName());
+        return "Collection<" + listItemJavaType + ">";
     }
 
     public String getJavaFieldTypeForBuilder(Set<String> imports) {
-        imports.add(List.class.getName());
-        return "List<" + ("?".equals(listItemJavaType) ? "Object" : listItemJavaType) + ">";
+        imports.add(Collection.class.getName());
+        return "Collection<" + ("?".equals(listItemJavaType) ? "Object" : listItemJavaType) + ">";
     }
 
     @Override
@@ -108,7 +109,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
                 return Collections.singleton("java.lang.String");
 
             } else if (effectiveListValueType == JsonObjectType.LIST) {
-                return Collections.singleton("java.util.List");
+                return Collections.singleton("java.util.Collection");
 
             } else {
                 for (String templateType : listItemTypes) {
@@ -150,7 +151,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
                 indent(indent) + " * <p>Sets the " + name + " field.</p>\n",
                 notesJavaDoc.toString(),
                 indent(indent) + " *\n",
-                indent(indent) + " * @param " + name + " Typically a List of " + valueTypesJavaDocList + ".\n",
+                indent(indent) + " * @param " + name + " Typically a Collection of " + valueTypesJavaDocList + ".\n",
                 indent(indent) + " * @return this builder.\n",
                 indent(indent) + " */\n",
                 indent(indent) + "public Builder " + name + "(" + getJavaFieldType(imports) + " " + name + ") {\n",
@@ -180,7 +181,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
                 indent(indent) + " * @deprecated no replacement\n",
                 indent(indent) + " */\n",
                 indent(indent) + "@Deprecated\n",
-                indent(indent) + "public Builder " + name + "(Class<?> " + nameViewClass + ", List<?> " + nameModels + ") {\n",
+                indent(indent) + "public Builder " + name + "(Class<?> " + nameViewClass + ", Collection<?> " + nameModels + ") {\n",
                 indent(indent + 1) + "this." + name + " = " + nameModels + ".stream()\n",
                 indent(indent + 3) + ".map((" + nameModel + ") -> request.createView(" + nameViewClass + ", " + nameModel + "))\n",
                 indent(indent + 3) + ".filter((" + nameView + ") -> " + nameView + " != null)\n",

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinitionList.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinitionList.java
@@ -146,7 +146,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
             notesJavaDoc.append(indent(indent)).append(" * <p>").append(note).append("</p>\n");
         }
 
-        String[] method1_1 = {
+        String[] method1 = {
                 indent(indent) + "/**\n",
                 indent(indent) + " * <p>Sets the " + name + " field.</p>\n",
                 notesJavaDoc.toString(),
@@ -175,7 +175,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
             return this;
         }
          */
-        String[] method1_2 = {
+        String[] method2 = {
                 indent(indent) + "/**\n",
                 indent(indent) + " * <p>Adds a single item to the " + name + " field.</p>\n",
                 notesJavaDoc.toString(),
@@ -207,7 +207,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
             return this;
         }
          */
-        String[] method1_3 = {
+        String[] method3 = {
                 indent(indent) + "/**\n",
                 indent(indent) + " * <p>Adds a Collection of items to the " + name + " field.</p>\n",
                 notesJavaDoc.toString(),
@@ -225,33 +225,6 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
         };
 
         /**
-         * @deprecated no replacement.
-         */
-        /*
-        @Deprecated
-        public Builder authors(Class<?> authorsViewClass, List<?> authorsModels) {
-            this.authors = authorsModels.stream()
-                    .map((authorsModel) -> request.createView(authorsViewClass, authorModel))
-                    .filter((authorsView) -> authorsView != null)
-                    .collect(Collectors.toList());
-            return this;
-        }
-         */
-        String[] method2 = {
-                indent(indent) + "/**\n",
-                indent(indent) + " * @deprecated no replacement\n",
-                indent(indent) + " */\n",
-                indent(indent) + "@Deprecated\n",
-                indent(indent) + "public Builder " + name + "(Class<?> " + nameViewClass + ", Collection<?> " + nameModels + ") {\n",
-                indent(indent + 1) + "this." + name + " = " + nameModels + ".stream()\n",
-                indent(indent + 3) + ".map((" + nameModel + ") -> request.createView(" + nameViewClass + ", " + nameModel + "))\n",
-                indent(indent + 3) + ".filter((" + nameView + ") -> " + nameView + " != null)\n",
-                indent(indent + 3) + ".collect(Collectors.toList());\n",
-                indent(indent + 1) + "return this;\n",
-                indent(indent) + "}"
-        };
-
-        /**
          * @deprecated Use {@link #addToArticleBody(Object)} instead.
          */
         /*
@@ -264,7 +237,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
             return this;
         }
          */
-        String[] method3 = {
+        String[] method4 = {
                 indent(indent) + "/**\n",
                 indent(indent) + " * @deprecated Use {@link #addTo" + StyleguideStringUtils.toPascalCase(name) + "(Object)} instead.\n",
                 indent(indent) + " */\n",
@@ -283,6 +256,33 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
          */
         /*
         @Deprecated
+        public Builder authors(Class<?> authorsViewClass, List<?> authorsModels) {
+            this.authors = authorsModels.stream()
+                    .map((authorsModel) -> request.createView(authorsViewClass, authorModel))
+                    .filter((authorsView) -> authorsView != null)
+                    .collect(Collectors.toList());
+            return this;
+        }
+         */
+        String[] method5 = {
+                indent(indent) + "/**\n",
+                indent(indent) + " * @deprecated no replacement\n",
+                indent(indent) + " */\n",
+                indent(indent) + "@Deprecated\n",
+                indent(indent) + "public Builder " + name + "(Class<?> " + nameViewClass + ", Collection<?> " + nameModels + ") {\n",
+                indent(indent + 1) + "this." + name + " = " + nameModels + ".stream()\n",
+                indent(indent + 3) + ".map((" + nameModel + ") -> request.createView(" + nameViewClass + ", " + nameModel + "))\n",
+                indent(indent + 3) + ".filter((" + nameView + ") -> " + nameView + " != null)\n",
+                indent(indent + 3) + ".collect(Collectors.toList());\n",
+                indent(indent + 1) + "return this;\n",
+                indent(indent) + "}"
+        };
+
+        /**
+         * @deprecated no replacement.
+         */
+        /*
+        @Deprecated
         public Builder addAuthors(Class<?> authorsViewClass, Object authorsModel) {
             Object authors = request.createView(authorsViewClass, authorsModel);
             if (authors != null) {
@@ -291,7 +291,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
             return this;
         }
          */
-        String[] method4 = {
+        String[] method6 = {
                 indent(indent) + "/**\n",
                 indent(indent) + " * @deprecated no replacement\n",
                 indent(indent) + " */\n",
@@ -305,20 +305,18 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
                 indent(indent) + "}"
         };
 
-        builder.append(Arrays.stream(method1_1).collect(Collectors.joining(""))).append("\n\n");
+        builder.append(Arrays.stream(method1).collect(Collectors.joining(""))).append("\n\n");
 
-        builder.append(Arrays.stream(method1_2).collect(Collectors.joining(""))).append("\n\n");
+        builder.append(Arrays.stream(method2).collect(Collectors.joining(""))).append("\n\n");
 
-        builder.append(Arrays.stream(method1_3).collect(Collectors.joining(""))).append("\n\n");
+        builder.append(Arrays.stream(method3).collect(Collectors.joining(""))).append("\n\n");
 
-        if (!removeDeprecations) {
-            builder.append(Arrays.stream(method2).collect(Collectors.joining(""))).append("\n\n");
-        }
-
-        builder.append(Arrays.stream(method3).collect(Collectors.joining(""))).append(removeDeprecations ? "" : "\n\n");
+        builder.append(Arrays.stream(method4).collect(Collectors.joining(""))).append(removeDeprecations ? "" : "\n\n");
 
         if (!removeDeprecations) {
-            builder.append(Arrays.stream(method4).collect(Collectors.joining("")));
+            builder.append(Arrays.stream(method5).collect(Collectors.joining(""))).append("\n\n");
+
+            builder.append(Arrays.stream(method6).collect(Collectors.joining("")));
         }
 
         return builder.toString();

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinitionList.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateFieldDefinitionList.java
@@ -146,7 +146,7 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
             notesJavaDoc.append(indent(indent)).append(" * <p>").append(note).append("</p>\n");
         }
 
-        String[] method1 = {
+        String[] method1_1 = {
                 indent(indent) + "/**\n",
                 indent(indent) + " * <p>Sets the " + name + " field.</p>\n",
                 notesJavaDoc.toString(),
@@ -161,13 +161,74 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
         };
 
         /**
-         * Sets the articleBody field.
+         * Adds a single item to the articleBody field.
          *
-         * @param articleBodyViewClass the articleBody views class, typically a Class of {@link FigureView}.
-         * @param articleBodyModels the models powering the articleBody views.
+         * @param articleBody the item to add, typically a {@link FigureView}.
          * @return this builder.
          */
         /*
+        public Builder addToAuthors(Object authors) {
+            if (this.authors == null) {
+                this.authors = new ArrayList<>();
+            }
+            this.authors.add(authors);
+            return this;
+        }
+         */
+        String[] method1_2 = {
+                indent(indent) + "/**\n",
+                indent(indent) + " * <p>Adds a single item to the " + name + " field.</p>\n",
+                notesJavaDoc.toString(),
+                indent(indent) + " *\n",
+                indent(indent) + " * @param " + name + " the item to add, typically a " + valueTypesJavaDocList + ".\n",
+                indent(indent) + " * @return this builder.\n",
+                indent(indent) + " */\n",
+                indent(indent) + "public Builder addTo" + StyleguideStringUtils.toPascalCase(name) + "(Object " + name + ") {\n",
+                indent(indent + 1) + "if (this." + name + " == null) {\n",
+                indent(indent + 2) + "this." + name + " = new ArrayList<>();\n",
+                indent(indent + 1) + "}\n",
+                indent(indent + 1) + "this." + name + ".add(" + name + ");\n",
+                indent(indent + 1) + "return this;\n",
+                indent(indent) + "}"
+        };
+
+        /**
+         * Adds a Collection of items to the articleBody field.
+         *
+         * @param articleBody the items to add, typically a {@link FigureView}.
+         * @return this builder.
+         */
+        /*
+        public Builder addAllToAuthors(Collection<?> authors) {
+            if (this.authors == null) {
+                this.authors = new ArrayList<>();
+            }
+            this.authors.addAll(authors);
+            return this;
+        }
+         */
+        String[] method1_3 = {
+                indent(indent) + "/**\n",
+                indent(indent) + " * <p>Adds a Collection of items to the " + name + " field.</p>\n",
+                notesJavaDoc.toString(),
+                indent(indent) + " *\n",
+                indent(indent) + " * @param " + name + " the items to add, typically a " + valueTypesJavaDocList + ".\n",
+                indent(indent) + " * @return this builder.\n",
+                indent(indent) + " */\n",
+                indent(indent) + "public Builder addAllTo" + StyleguideStringUtils.toPascalCase(name) + "(" + getJavaFieldType(imports) + " " + name + ") {\n",
+                indent(indent + 1) + "if (this." + name + " == null) {\n",
+                indent(indent + 2) + "this." + name + " = new ArrayList<>();\n",
+                indent(indent + 1) + "}\n",
+                indent(indent + 1) + "this." + name + ".addAll(" + name + ");\n",
+                indent(indent + 1) + "return this;\n",
+                indent(indent) + "}"
+        };
+
+        /**
+         * @deprecated no replacement.
+         */
+        /*
+        @Deprecated
         public Builder authors(Class<?> authorsViewClass, List<?> authorsModels) {
             this.authors = authorsModels.stream()
                     .map((authorsModel) -> request.createView(authorsViewClass, authorModel))
@@ -191,12 +252,10 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
         };
 
         /**
-         * Adds an item to the articleBody field.
-         *
-         * @param articleBody the view to set, typically a {@link FigureView}.
-         * @return this builder.
+         * @deprecated Use {@link #addToArticleBody(Object)} instead.
          */
         /*
+        @Deprecated
         public Builder addAuthors(Object authors) {
             if (this.authors == null) {
                 this.authors = new ArrayList<>();
@@ -207,12 +266,9 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
          */
         String[] method3 = {
                 indent(indent) + "/**\n",
-                indent(indent) + " * <p>Adds an item to the " + name + " field.</p>\n",
-                notesJavaDoc.toString(),
-                indent(indent) + " *\n",
-                indent(indent) + " * @param " + name + " the view to set, typically a " + valueTypesJavaDocList + ".\n",
-                indent(indent) + " * @return this builder.\n",
+                indent(indent) + " * @deprecated Use {@link #addTo" + StyleguideStringUtils.toPascalCase(name) + "(Object)} instead.\n",
                 indent(indent) + " */\n",
+                indent(indent) + "@Deprecated\n",
                 indent(indent) + "public Builder add" + StyleguideStringUtils.toPascalCase(name) + "(Object " + name + ") {\n",
                 indent(indent + 1) + "if (this." + name + " == null) {\n",
                 indent(indent + 2) + "this." + name + " = new ArrayList<>();\n",
@@ -223,13 +279,10 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
         };
 
         /**
-         * Adds an item to the articleBody field.
-         *
-         * @param articleBodyViewClass the articleBody view class, typically a Class of {@link FigureView}.
-         * @param articleBodyModel the model powering the articleBody view.
-         * @return this builder.
+         * @deprecated no replacement.
          */
         /*
+        @Deprecated
         public Builder addAuthors(Class<?> authorsViewClass, Object authorsModel) {
             Object authors = request.createView(authorsViewClass, authorsModel);
             if (authors != null) {
@@ -252,7 +305,11 @@ class TemplateFieldDefinitionList extends TemplateFieldDefinition {
                 indent(indent) + "}"
         };
 
-        builder.append(Arrays.stream(method1).collect(Collectors.joining(""))).append("\n\n");
+        builder.append(Arrays.stream(method1_1).collect(Collectors.joining(""))).append("\n\n");
+
+        builder.append(Arrays.stream(method1_2).collect(Collectors.joining(""))).append("\n\n");
+
+        builder.append(Arrays.stream(method1_3).collect(Collectors.joining(""))).append("\n\n");
 
         if (!removeDeprecations) {
             builder.append(Arrays.stream(method2).collect(Collectors.joining(""))).append("\n\n");


### PR DESCRIPTION
Assume the field name is "items".

The current view Builder method signatures are:

```
public Builder items(List<?> items);

public Builder addItems(Object items);
```

This PR changes the `#items` method to be a Collection, deprecate the `#addItems` method and add 2 new ones with names that read better to handle the add 1 and add many cases:

```
public Builder items(Collection<?> items);

public Builder addToItems(Object items);

public Builder addAllToItems(Collection<?> items);

@Deprecated
public Builder addItems(Object items);
```
