### PR TITLE
Fix reference from options -> elementOptions, so that blockName can b…

### DIFF
--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -339,7 +339,7 @@ module.exports = function (config, req, res, context) {
 
         var value = this[name];
         var fnOptions = { data: { } };
-        fnOptions.data[ELEMENT_NAME_DATA] = options.data[BLOCK_NAME_DATA] + '-' + name;
+        fnOptions.data[ELEMENT_NAME_DATA] = elementOptions.data[BLOCK_NAME_DATA] + '-' + name;
 
         if (elementOptions.hash.noWith) {
             value = elementOptions.fn(this, fnOptions);


### PR DESCRIPTION
…e used in `element` helper.

This fixes the following template scenario:

```
{{#defineBlock "MyBlock"}}
    {{#defineElement "bar" noWith=true}}
        <div class="{{elementName}}">{{bar}}</div>
    {{/defineElement}}

    {{#defineElement "foo" noWith=true}}
        <div class="{{elementName}}">
            {{element "bar"}}
        </div>
    {{/defineElement}}
{{/defineBlock}}
```

which currently outputs:

```
<div class="foo">
    <div class="undefined-bar">...</div>
</div>
```
