### PR TITLE
Fallback on `elementOptions.data` when `options.data` for a given blo…

### DIFF
--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -339,7 +339,9 @@ module.exports = function (config, req, res, context) {
 
         var value = this[name];
         var fnOptions = { data: { } };
-        fnOptions.data[ELEMENT_NAME_DATA] = options.data[BLOCK_NAME_DATA] + '-' + name;
+        var blockName = options.data[BLOCK_NAME_DATA] || elementOptions.data[BLOCK_NAME_DATA];
+
+        fnOptions.data[ELEMENT_NAME_DATA] = blockName + '-' + name;
 
         if (elementOptions.hash.noWith) {
             value = elementOptions.fn(this, fnOptions);


### PR DESCRIPTION
…ckName is undefined.

This allows templates with nested element definitions to access the blockname instead of outputting `undefined` in the template. 

Here's a sample template:

```
{{#defineBlock "NestedBlock"}}
    {{#defineElement "foo"}}
        <div class="{{elementName}}">{{this}}</div>
    {{/defineElement}}

    {{#defineElement "bar" noWith=true}}
        <div class="{{elementName}}">
            {{element "foo"}}
        </div>
    {{/defineElement}}

    {{#defineBlockContainer}}
        <div class="{{blockName}}">
            {{#defineBlockBody}}
                {{element "bar"}}
            {{/defineBlockBody}}
        </div>
    {{/defineBlockContainer}}
{{/defineBlock}}
```
