### PR TITLE
Add support for rendering JSON views

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>com.psddev</groupId>
         <artifactId>styleguide-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>styleguide-example</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>war</packaging>
 
     <name>BrightSpot Styleguide - Example</name>

--- a/example/styleguide/README.md
+++ b/example/styleguide/README.md
@@ -133,6 +133,11 @@ This entry is required unless the object is referenced as either
 `displayOptions` ([example](components/list/three-items.json)) or
 `extraAttributes` ([example](components/link/index.json)).
 
+`_view`
+
+Path used to create a view that renders JSON output. The `_view` entry should be used instead of `_template` when the
+output for the view should be directly serialized to JSON using a `JsonViewRenderer`.
+
 `_wrapper`
 
 Location of another file that should wrap the JSON object. That file should

--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -73,14 +73,15 @@ module.exports = function (config, req, res, context) {
     // Resolve all _template paths.
     resolveTemplatePath(data, selectedLibrary);
 
-    // Validate the JSON data. Exceptions for the special keys we have that are maps, so they don't need _template
+    // Validate the JSON data. Exceptions for the special keys we have that are maps, so they don't need _template or _view
     traverse(data).forEach(function (value) {
         if (_.isPlainObject(value)
-                && !value._template
-                && this.key.slice(0, 1) !== '_'
-                && this.key !== 'displayOptions'
-                && this.key !== 'extraAttributes'
-                && this.key !== 'jsonObject') {
+            && !value._template
+            && !value._view
+            && this.key.slice(0, 1) !== '_'
+            && this.key !== 'displayOptions'
+            && this.key !== 'extraAttributes'
+            && this.key !== 'jsonObject') {
 
             var safeParent = false;
 
@@ -91,7 +92,7 @@ module.exports = function (config, req, res, context) {
             });
 
             if(!safeParent) {
-                throw new Error("Object without _template entry at " + this.path.join('/') + "!");
+                throw new Error("Object without _template or _view entry at " + this.path.join('/') + "!");
             }
         }
     });
@@ -99,7 +100,7 @@ module.exports = function (config, req, res, context) {
     var projectLibrary = config.projectLibrary;
 
     // Wrap the example file data?
-    if (data._wrapper !== false) {
+    if (data._wrapper !== false && !data._view) {
         var wrapperPath = projectLibrary.findStyleguideFile(data._wrapper ? data._wrapper : '_wrapper.json');
 
         while (wrapperPath) {
@@ -130,6 +131,12 @@ module.exports = function (config, req, res, context) {
 
     function renderTemplate(data) {
         var templatePath = data._template;
+
+        // See if this is a JSON view and render the data as JSON using a simple HTML template
+        if (!templatePath && data._view) {
+            return renderJsonTemplate(data);
+        }
+
         var compiledTemplate = compiledTemplates[templatePath];
 
         if (!compiledTemplate) {
@@ -157,6 +164,23 @@ module.exports = function (config, req, res, context) {
         }
 
         return compiledTemplate(data);
+    }
+
+    function renderJsonTemplate(data) {
+        var jsonData = {
+            "json": JSON.stringify(data, removePrivateKeys, 2)
+        };
+        var jsonTemplate = fs.readFileSync(context.library.findStyleguideFile('/example-json.hbs'), 'utf8');
+        var jsonCompiledTemplate = handlebars.compile(jsonTemplate);
+
+        return jsonCompiledTemplate(jsonData);
+    }
+
+    function removePrivateKeys(key, value) {
+        if (key.slice(0, 1) === '_') {
+            return undefined;
+        }
+        return value;
     }
 
     handlebars.registerHelper('render', function (data, fullScope) {
@@ -191,7 +215,10 @@ module.exports = function (config, req, res, context) {
                 });
 
             } else {
-                var copy = data._template ? new Template() : {};
+                var copy = {};
+                if (data._template || data._view) {
+                    copy = new Template()
+                }
 
                 Object.keys(data).forEach(function (key) {
                     copy[key] = convert(data[key]);

--- a/lib/library.js
+++ b/lib/library.js
@@ -96,22 +96,6 @@ Library.prototype.forEachStyleguideGroup = function (callback) {
     }
 };
 
-Library.prototype.forEachStyleguideJsonGroup = function (callback) {
-    var styleguidePath = this._styleguidePath + "/_json";
-
-    if (styleguidePath) {
-        fs.readdirSync(styleguidePath).forEach(function (group) {
-            if (group.slice(0, 1) !== '_') {
-                var groupPath = path.join(styleguidePath, group);
-
-                if (fs.statSync(groupPath).isDirectory()) {
-                    callback(group, groupPath);
-                }
-            }
-        });
-    }
-};
-
 Library.prototype.forEachWebappFile = function (callback) {
     var seen = { };
     var webappPath = this._webappPath;

--- a/lib/library.js
+++ b/lib/library.js
@@ -96,6 +96,22 @@ Library.prototype.forEachStyleguideGroup = function (callback) {
     }
 };
 
+Library.prototype.forEachStyleguideJsonGroup = function (callback) {
+    var styleguidePath = this._styleguidePath + "/_json";
+
+    if (styleguidePath) {
+        fs.readdirSync(styleguidePath).forEach(function (group) {
+            if (group.slice(0, 1) !== '_') {
+                var groupPath = path.join(styleguidePath, group);
+
+                if (fs.statSync(groupPath).isDirectory()) {
+                    callback(group, groupPath);
+                }
+            }
+        });
+    }
+};
+
 Library.prototype.forEachWebappFile = function (callback) {
     var seen = { };
     var webappPath = this._webappPath;

--- a/lib/server.js
+++ b/lib/server.js
@@ -218,6 +218,33 @@ module.exports = function (config) {
             }
         });
 
+
+        // Finds all groups of JSON examples in the styleguide/_json directory.
+        library.forEachStyleguideJsonGroup(function (group, groupPath) {
+            var jsonExamples = [ ];
+
+            // Finds all json examples in this group.
+            fs.readdirSync(groupPath).forEach(function (example) {
+                if (example.slice(0, 1) !== '_') {
+                    var examplePath = path.join(groupPath, example);
+
+                    if (fs.statSync(examplePath).isDirectory()) {
+                        jsonExamples.push({
+                            name: label(example),
+                            url: library.urlPrefix + '/_json/' + group + '/' + example + originalUrlSearch
+                        });
+                    }
+                }
+            });
+
+            if (jsonExamples.length > 0) {
+                groups.push({
+                    name: 'Json: ' + label(group),
+                    examples: jsonExamples
+                });
+            }
+        });
+
         // Which devices to display?
         context.resetDisplayDevicesUrl = url.parse(req.originalUrl, true);
         var availableDevices = context.availableDevices = [ ];

--- a/lib/server.js
+++ b/lib/server.js
@@ -217,34 +217,7 @@ module.exports = function (config) {
                 });
             }
         });
-
-
-        // Finds all groups of JSON examples in the styleguide/_json directory.
-        library.forEachStyleguideJsonGroup(function (group, groupPath) {
-            var jsonExamples = [ ];
-
-            // Finds all json examples in this group.
-            fs.readdirSync(groupPath).forEach(function (example) {
-                if (example.slice(0, 1) !== '_') {
-                    var examplePath = path.join(groupPath, example);
-
-                    if (fs.statSync(examplePath).isDirectory()) {
-                        jsonExamples.push({
-                            name: label(example),
-                            url: library.urlPrefix + '/_json/' + group + '/' + example + originalUrlSearch
-                        });
-                    }
-                }
-            });
-
-            if (jsonExamples.length > 0) {
-                groups.push({
-                    name: 'Json: ' + label(group),
-                    examples: jsonExamples
-                });
-            }
-        });
-
+        
         // Which devices to display?
         context.resetDisplayDevicesUrl = url.parse(req.originalUrl, true);
         var availableDevices = context.availableDevices = [ ];

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <artifactId>styleguide-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>BrightSpot Styleguide</name>

--- a/styleguide/example-json.hbs
+++ b/styleguide/example-json.hbs
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+<head></head>
+    <body>
+        <pre><code>{{{json}}}</code></pre>
+    </body>
+</html>

--- a/viewgenerator/pom.xml
+++ b/viewgenerator/pom.xml
@@ -9,12 +9,12 @@
     <parent>
         <groupId>com.psddev</groupId>
         <artifactId>styleguide-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>styleguide</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>BrightSpot Styleguide - View Generator</name>

--- a/viewgenerator/src/main/java/com/psddev/styleguide/DataUrlTemplateOverrideException.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/DataUrlTemplateOverrideException.java
@@ -3,6 +3,6 @@ package com.psddev.styleguide;
 public class DataUrlTemplateOverrideException extends RuntimeException {
 
     public DataUrlTemplateOverrideException(JsonDataFile jsonDataFile, String dataUrl) {
-        super("Error in [" + jsonDataFile.getFileName() + "] for _dataUrl [" + dataUrl + "]. Can't override _template field!");
+        super("Error in [" + jsonDataFile.getFileName() + "] for _dataUrl [" + dataUrl + "]. Can't override _template or _view field!");
     }
 }

--- a/viewgenerator/src/main/java/com/psddev/styleguide/JsonDataFile.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/JsonDataFile.java
@@ -74,7 +74,7 @@ class JsonDataFile {
     }
 
     public String getTemplateName() {
-        return (String) jsonData.get("_template");
+        return JsonTemplateObject.getTemplateName(jsonData);
     }
 
     public JsonTemplateObject getTemplateObject(JsonDataFiles jsonDataFiles) {
@@ -185,7 +185,7 @@ class JsonDataFile {
     private JsonTemplateObject resolveJsonTemplateObject(JsonDataFiles jsonDataFiles, Map<String, ?> map, String fieldNotes) {
         // check if the special delegate key is the only key present and create a dummy template object.
         if (map.get(DELEGATE_TEMPLATE_OBJECT_KEY) != null && map.size() == 1) {
-            return new JsonTemplateObject(null, null, null, null);
+            return new JsonTemplateObject(null, null, null, null, null);
         }
 
         String dataUrl = (String) map.get("_dataUrl");
@@ -194,8 +194,8 @@ class JsonDataFile {
             JsonDataFile jsonDataFile = resolveDataUrl(dataUrl, jsonDataFiles);
             if (jsonDataFile != null) {
 
-                // don't allow the use of both _dataUrl and _template since template should never be overridden.
-                if (map.get("_template") != null) {
+                // don't allow the use of _dataUrl and either _template or _view since they should never be overridden.
+                if (JsonTemplateObject.getTemplateName(map) != null) {
                     throw new DataUrlTemplateOverrideException(this, dataUrl);
                 }
 
@@ -227,7 +227,8 @@ class JsonDataFile {
         } else {
             Map<String, JsonObject> fields = new LinkedHashMap<>();
 
-            String template = (String) map.get("_template");
+            String template = JsonTemplateObject.getTemplateName(map);
+            JsonTemplateObject.TemplateFormat format = JsonTemplateObject.getTemplateFormat(map);
             String templateNotes = (String) map.get("_notes");
 
             if (template != null) {
@@ -245,7 +246,7 @@ class JsonDataFile {
                     }
                 });
 
-                return new JsonTemplateObject(StringUtils.ensureStart(template, "/"), fields, fieldNotes, templateNotes);
+                return new JsonTemplateObject(StringUtils.ensureStart(template, "/"), fields, fieldNotes, templateNotes, format);
 
             } else {
                 throw new MissingTemplateException(this, map);

--- a/viewgenerator/src/main/java/com/psddev/styleguide/JsonObjectType.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/JsonObjectType.java
@@ -27,7 +27,7 @@ enum JsonObjectType {
             return LIST;
 
         } else if (object instanceof Map) {
-            if (((Map<?, ?>) object).get("_template") != null) {
+            if (JsonTemplateObject.getTemplateName((Map<?, ?>) object) != null) {
                 return TEMPLATE_OBJECT;
             } else {
                 return MAP;

--- a/viewgenerator/src/main/java/com/psddev/styleguide/JsonTemplateObject.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/JsonTemplateObject.java
@@ -1,11 +1,19 @@
 package com.psddev.styleguide;
 
+import static com.psddev.styleguide.JsonTemplateObject.TemplateFormat.Handlebars;
+import static com.psddev.styleguide.JsonTemplateObject.TemplateFormat.Json;
+
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Set;
 
+import com.psddev.dari.util.ObjectUtils;
+
 class JsonTemplateObject extends JsonObject {
+
+    public static final String TEMPLATE_KEY = "_template";
+    public static final String JSON_VIEW_KEY = "_view";
 
     private String template;
 
@@ -13,12 +21,23 @@ class JsonTemplateObject extends JsonObject {
 
     private String fieldNotes;
     private String templateNotes;
+    private TemplateFormat templateFormat;
 
-    public JsonTemplateObject(String template, Map<String, JsonObject> fields, String fieldNotes, String templateNotes) {
+    public enum TemplateFormat {
+        Handlebars,
+        Json
+    }
+
+    public JsonTemplateObject(String template,
+                              Map<String, JsonObject> fields,
+                              String fieldNotes,
+                              String templateNotes,
+                              TemplateFormat templateFormat) {
         this.template = template;
         this.fields = fields != null ? fields : Collections.emptyMap();
         this.fieldNotes = fieldNotes;
         this.templateNotes = templateNotes;
+        this.templateFormat = templateFormat;
     }
 
     public String getTemplateName() {
@@ -40,6 +59,24 @@ class JsonTemplateObject extends JsonObject {
 
     public String getTemplateNotes() {
         return templateNotes;
+    }
+
+    public TemplateFormat getTemplateFormat() {
+        return templateFormat;
+    }
+
+    public static String getTemplateName(Map<?, ?> map) {
+        return (String) ObjectUtils.firstNonBlank(map.get(TEMPLATE_KEY), map.get(JSON_VIEW_KEY));
+    }
+
+    public static TemplateFormat getTemplateFormat(Map<?, ?> map) {
+        if (!ObjectUtils.isBlank(map.get(TEMPLATE_KEY))) {
+            return Handlebars;
+        } else if (!ObjectUtils.isBlank(map.get(JSON_VIEW_KEY))) {
+            return Json;
+        }
+
+        return null;
     }
 
     @Override

--- a/viewgenerator/src/main/java/com/psddev/styleguide/MissingTemplateException.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/MissingTemplateException.java
@@ -11,6 +11,6 @@ public class MissingTemplateException extends RuntimeException {
     }
 
     public MissingTemplateException(JsonDataFile jsonDataFile, Map<String, ?> map) {
-        super("Error in [" + jsonDataFile.getFileName() + "]. No _template in map [" + ObjectUtils.toJson(map) + "].");
+        super("Error in [" + jsonDataFile.getFileName() + "]. No _template or _view in map [" + ObjectUtils.toJson(map) + "].");
     }
 }

--- a/viewgenerator/src/main/java/com/psddev/styleguide/StyleguideStringUtils.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/StyleguideStringUtils.java
@@ -1,5 +1,7 @@
 package com.psddev.styleguide;
 
+import com.psddev.dari.util.StringUtils;
+
 class StyleguideStringUtils {
 
     /** Converts a java field name into its method equivalent minus the get/set/add prefix */
@@ -17,6 +19,14 @@ class StyleguideStringUtils {
 
     /** Converts a file name into its java class name equivalent. */
     public static String toJavaClassCase(String string) {
-        return toJavaMethodCase(string);
+        if (string != null && !string.isEmpty()) {
+            char first = string.charAt(0);
+            if (" -_.$".indexOf(first) > -1) {
+                string = string.substring(1);
+            }
+            return StringUtils.toPascalCase(string);
+        } else {
+            return string;
+        }
     }
 }

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinition.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinition.java
@@ -264,13 +264,18 @@ class TemplateDefinition {
             javaClassNamePrefix = "";
         }
 
-        String className;
+        String className = name;
 
-        int lastSlashAt = name.lastIndexOf('/');
-        if (lastSlashAt >= 0) {
-            className = name.substring(lastSlashAt + 1);
+        if (name.contains(".")) {
+            int lastDotAt = name.lastIndexOf('.');
+            if (lastDotAt > 0) {
+                className = name.substring(lastDotAt + 1);
+            }
         } else {
-            className = name;
+            int lastSlashAt = name.lastIndexOf('/');
+            if (lastSlashAt >= 0) {
+                className = name.substring(lastSlashAt + 1);
+            }
         }
 
         return javaClassNamePrefix + StyleguideStringUtils.toJavaClassCase(className) + "View";

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinition.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinition.java
@@ -124,6 +124,12 @@ class TemplateDefinition {
         final String viewRequestClassName = "com.psddev.cms.view.ViewRequest";
         final String viewInterfaceClassName = "com.psddev.cms.view.ViewInterface";
         final String handlebarsTemplateClassName = "com.psddev.handlebars.HandlebarsTemplate";
+        final String jsonTemplateClassName = "com.psddev.cms.view.JsonView";
+        String templateClassName = handlebarsTemplateClassName;
+
+        if (isJsonFormat()) {
+            templateClassName = jsonTemplateClassName;
+        }
 
         if (!removeDeprecations) {
             imports.add(viewRequestClassName);
@@ -133,7 +139,7 @@ class TemplateDefinition {
             imports.add(viewInterfaceClassName);
         }
 
-        imports.add(handlebarsTemplateClassName);
+        imports.add(templateClassName);
 
         builder.append("/* AUTO-GENERATED FILE.  DO NOT MODIFY.\n");
         builder.append(" *\n");
@@ -156,7 +162,13 @@ class TemplateDefinition {
         if (classExists(viewInterfaceClassName)) {
             builder.append("@").append(toSimpleClassName(viewInterfaceClassName)).append("\n");
         }
-        builder.append("@").append(toSimpleClassName(handlebarsTemplateClassName)).append("(\"").append(StringUtils.removeStart(name, "/")).append("\")\n");
+
+        builder.append("@").append(toSimpleClassName(templateClassName));
+        if (!isJsonFormat()) {
+            builder.append("(\"").append(StringUtils.removeStart(name, "/")).append("\")");
+        }
+        builder.append("\n");
+
         builder.append("public interface ").append(getJavaClassName()).append(" {\n");
 
         for (TemplateFieldDefinition fieldDef : fields) {
@@ -273,6 +285,14 @@ class TemplateDefinition {
         }
 
         return builder.toString();
+    }
+
+    /**
+     * @return true only if all templates specify a JSON format (they should be consistent)
+     */
+    private boolean isJsonFormat() {
+        return jsonTemplateObjects != null
+            && jsonTemplateObjects.stream().allMatch(template -> template.getTemplateFormat() == JsonTemplateObject.TemplateFormat.Json);
     }
 
     // Helper method to convert the String "com.package.name.ClassName" --> "ClassName"

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
@@ -43,9 +43,10 @@ class TemplateDefinitions {
 
         // find the common path prefix ensuring that the paths do not start with slash
         int commonPrefixIndex = PathUtils.getCommonPrefixIndex(
-                jsonTemplateObjectsMap.keySet().stream()
-                        .map(name -> StringUtils.removeStart(name, "/"))
-                        .collect(Collectors.toList()), '/');
+                jsonTemplateObjects.stream()
+                    .filter(template -> template.getTemplateFormat() == JsonTemplateObject.TemplateFormat.Handlebars)
+                    .map(template -> StringUtils.removeStart(template.getTemplateName(), "/"))
+                    .collect(Collectors.toList()), '/');
 
         definitions = new HashMap<>();
 

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
@@ -55,12 +55,18 @@ class TemplateDefinitions {
             String name = StringUtils.removeStart(entry.getKey(), "/");
 
             String commonName = name.substring(commonPrefixIndex);
-            String commonNamePath;
-            int lastSlashAt = commonName.lastIndexOf('/');
-            if (lastSlashAt > 0) {
-                commonNamePath = commonName.substring(0, lastSlashAt);
+            String commonNamePath = "";
+
+            if (commonName.contains(".")) {
+                int lastDotAt = commonName.lastIndexOf('.');
+                if (lastDotAt > 0) {
+                    commonNamePath = commonName.substring(0, lastDotAt);
+                }
             } else {
-                commonNamePath = "";
+                int lastSlashAt = commonName.lastIndexOf('/');
+                if (lastSlashAt > 0) {
+                    commonNamePath = commonName.substring(0, lastSlashAt);
+                }
             }
 
             String javaPackageName = javaPackagePrefix + commonNamePath.replaceAll("/", ".");

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.psddev.dari.util.StringUtils;
 
@@ -41,36 +40,26 @@ class TemplateDefinitions {
             list.add(jsonTemplateObject);
         }
 
-        // find the common path prefix ensuring that the paths do not start with slash
-        int commonPrefixIndex = PathUtils.getCommonPrefixIndex(
-                jsonTemplateObjects.stream()
-                    .filter(template -> template.getTemplateFormat() == JsonTemplateObject.TemplateFormat.Handlebars)
-                    .map(template -> StringUtils.removeStart(template.getTemplateName(), "/"))
-                    .collect(Collectors.toList()), '/');
-
         definitions = new HashMap<>();
 
         jsonTemplateObjectsMap.entrySet().forEach((entry) -> {
 
             // again for consistency, remove the leading slash
             String name = StringUtils.removeStart(entry.getKey(), "/");
+            String namePath = "";
+            int lastPathIndex = -1;
 
-            String commonName = name.substring(commonPrefixIndex);
-            String commonNamePath = "";
-
-            if (commonName.contains(".")) {
-                int lastDotAt = commonName.lastIndexOf('.');
-                if (lastDotAt > 0) {
-                    commonNamePath = commonName.substring(0, lastDotAt);
-                }
+            if (name.contains(".")) {
+                lastPathIndex = name.lastIndexOf('.');
             } else {
-                int lastSlashAt = commonName.lastIndexOf('/');
-                if (lastSlashAt > 0) {
-                    commonNamePath = commonName.substring(0, lastSlashAt);
-                }
+                lastPathIndex = name.lastIndexOf('/');
             }
 
-            String javaPackageName = javaPackagePrefix + commonNamePath.replaceAll("/", ".");
+            if (lastPathIndex > 0) {
+                namePath = name.substring(0, lastPathIndex);
+            }
+
+            String javaPackageName = javaPackagePrefix + namePath.replaceAll("/", ".");
 
             if (!mapTemplates.contains(name)) {
                 definitions.put(StringUtils.ensureStart(name, "/"), new TemplateDefinition(

--- a/viewgenerator/src/test/java/com/psddev/styleguide/TestMissingTemplate.java
+++ b/viewgenerator/src/test/java/com/psddev/styleguide/TestMissingTemplate.java
@@ -8,7 +8,7 @@ public class TestMissingTemplate {
     public void testMissingTemplate() throws Exception {
         ViewClassGenerator generator = TestUtils.getDefaultGeneratorForClass(getClass());
 
-        // should throw an exception for having a data file without a _template field
+        // should throw an exception for having a data file without a _template or _view field
         generator.getGeneratedClasses();
     }
 }


### PR DESCRIPTION
Add a new JSON template format with a key of `_view` which denotes the path for the `View` interface. 

Generated `_view` classes have a `JsonView` annotation (instead of `HandlebarsTemplate`) which renders using `JsonViewRenderer`.

The styleguide will render the output of a `_view` template as a JSON string in a simple HTML template supplied in the `example-json.hbs` handlebars template. And `_view` paths can be expressed using Java-package syntax (e.g. `app.page.Home`).

Example:

``` javascript
{
  "_view": "app.VideoPlaylist",

  "text": "{{words(4)}}",
  "image": "{{image(612, 380)}}",
  "videos": [{
    "_dataUrl": "/block/promo/video.json",
    "_repeat": 3
  }]
}
```

And the view interface would look like this:

``` @ViewInterface
@JsonView
public interface VideoPlaylistView {
```
