### PR TITLE
Update nested element `blockName` according to extended element `blockN…

### DIFF
--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -246,6 +246,7 @@ module.exports = function (config, req, res, context) {
 
     // Defines a block.
     var DATA_PREFIX = '_brightspot_';
+    var ELEMENT_DATA = DATA_PREFIX + 'element';
     var BLOCK_NAME_DATA = DATA_PREFIX + 'blockName';
     var DEFINE_BLOCK_CONTAINER_IN_EXTEND_DATA = DATA_PREFIX + 'defineBlockContainerInExtend';
 
@@ -263,6 +264,7 @@ module.exports = function (config, req, res, context) {
         if (extend) {
             var template = compile(extend);
             var templateOptions = { data: { } };
+            templateOptions.data[BLOCK_NAME_DATA] = name;
             templateOptions.data[DEFINE_BLOCK_CONTAINER_IN_EXTEND_DATA] = true;
 
             template(this, templateOptions);
@@ -331,11 +333,19 @@ module.exports = function (config, req, res, context) {
 
     // Renders the named element.
     handlebars.registerHelper('element', function (name, options) {
+        var self = this;
         var elementOptions = this[ELEMENT_DEFINITION_DATA_PREFIX + name];
 
         if (!elementOptions) {
             throw new Error('[' + name + '] element not defined!');
         }
+
+        // does this element contain nested elements?
+        Object.keys(this).filter(function (key) {
+            if (key.indexOf(ELEMENT_DATA) > -1 && options.data[BLOCK_NAME_DATA]) {
+                self[key].data[BLOCK_NAME_DATA] = options.data[BLOCK_NAME_DATA];
+            }
+        });
 
         var value = this[name];
         var fnOptions = { data: { } };


### PR DESCRIPTION
…ame`.

The example template below is being compiled in 2 different ways depending on which handlebars implementation you use:

```
{{#defineBlock "B" extend="A"}}
    {{#defineElement "foo" noWith=true}}
        <div class="{{elementName}}">
            {{element "bar"}}
        </div>
    {{/defineElement}}

    {{#defineBlockContainer}}
        {{#defineBlockBody}}
            {{element "foo"}}
        {{/defineBlockBody}}
    {{/defineBlockContainer}}
{{/defineBlock}} 
```

This change makes the node handlebars function like the Java handlebars. When dealing with nested elements within a `defineElement` block it makes sure that the `blockName` cascades down and prefixes the nested and extended child elements.
