### PR TITLE
Depend on specific version of iframe-resizer dependency to fix exampl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "font-awesome": "^4.4.0",
     "geopattern": "1.2.3",
     "handlebars": "^4.0.3",
-    "iframe-resizer": "^3.5.0",
+    "iframe-resizer": "3.5.0",
     "jquery": "2.1.4",
     "less": "^2.5.3",
     "less-middleware": "^2.0.1",


### PR DESCRIPTION
…e file iframe rendering.

The latest release (at this time v3.5.5) of https://github.com/davidjbradshaw/iframe-resizer is breaking our iframes and displays the following error in the devtools console:
Error:
`Uncaught SyntaxError: Unexpected token <`

For now this is the simplest solution until we can look into this further.
