### PR TITLE
Feature/var generator

### DIFF
--- a/example/styleguide/README.md
+++ b/example/styleguide/README.md
@@ -15,22 +15,6 @@ it won't show up in the styleguide navigation.
 
 ### Methods
 
-#### image
-
-```
-{{image(width, height)}}
-```
-
-URL to a randomly generated image.
-
-#### name
-
-```
-{{name()}}
-```
-
-Generates a random name; first and last
-
 #### date
 
 ```
@@ -57,6 +41,22 @@ Generates a random hex color with options to choose a luminosity value ranging f
 
 `"color":"hsl({{number([0,360])}}, 50%, 100%)"`
 
+#### image
+
+```
+{{image(width, height)}}
+```
+
+URL to a randomly generated image.
+
+#### name
+
+```
+{{name()}}
+```
+
+Generates a random name; first and last
+
 #### number
 
 ```
@@ -75,12 +75,6 @@ Generates a random number. Option to pass in an array to provide a range of numb
 
 ```
 {{sentences(sentenceCount, wordCount)}}
-```
-
-#### words
-
-```
-{{words(wordCount)}}
 ```
 
 #### stylesheet
@@ -111,6 +105,40 @@ Which will cause the styleguide to render a select list in the upper right. For 
 
 ![image](https://cldup.com/9ACNTLyBkb.png)
 
+#### var
+
+```
+{{var('foo')}}
+```
+
+Interpolates the value of a variable defined in your styleguide's `_config.json` file.
+
+For example if the contents of `_config.json` are:
+```
+{
+    vars: {
+        "color": "blue"
+    }
+}
+```
+
+and in your example json you used the generator like:
+
+```
+{
+    "title": "The sky is {{var('color')}} today"
+}
+```
+
+the `title` property would yield:
+
+`The sky is blue today`
+
+#### words
+
+```
+{{words(wordCount)}}
+```
 
 ## Special Entries
 

--- a/lib/data-generator.js
+++ b/lib/data-generator.js
@@ -4,7 +4,8 @@ var traverse = require('traverse');
 
 var Util = require('./util');
 
-function DataGenerator(context) {
+function DataGenerator(context, config) {
+    this.config = config;
     this.context = context;
     this.chance = new Chance(context.seed);
 }
@@ -135,6 +136,18 @@ DataGenerator.prototype.paragraphs = function (paragraphCount, sentenceCount, wo
     });
 };
 
+// `var` takes the provided key and looks up the value as defined in the `vars` of your styleguide config (_config.json)
+// If it is found, it returns the corresponding value otherwise it returns an Error object
+DataGenerator.prototype.var = function (key) {
+    if (this.config.vars) {
+        if (key in this.config.vars) {
+            return this.config.vars[key];
+        }
+    }
+
+    return new Error('this.config.vars is undefined. The `var()` generator expects that your styleguide _config.json contains vars. Or, maybe you misspelled the keyname?\n')
+};
+
 DataGenerator.prototype.process = function (data) {
     var self = this;
 
@@ -170,10 +183,15 @@ DataGenerator.prototype.process = function (data) {
                 }
 
                 try {
-                    return eval('self.' + invocation);
-
+                    var data = eval('self.' + invocation);
+                    if (data instanceof Error) {
+                        throw data;
+                    }
+                    else {
+                        return data;
+                    }
                 } catch (err) {
-                    throw new Error(invocation + ' is not a valid DataGenerator function invocation! ' + err.stack);
+                    throw new Error('DataGenerator execution error! ' + '\n\n' + err.stack);
                 }
             }));
         }

--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -123,7 +123,7 @@ module.exports = function (config, req, res, context) {
     }
 
     // post-process the JSON data.
-    new DataGenerator(context).process(data);
+    new DataGenerator(context, config).process(data);
 
     // Set up Handlebars cache.
     var compiledTemplates = { };


### PR DESCRIPTION
When authoring styleguide example data, it can be tedious to maintain values like API keys, URL params and other IDs when you have more than a couple examples that reference those values. This feature aims to provide a way to define variables at the global level, within the styleguide  `_config.json`, which can be interpolated back into the example JSON data through a generator call.

See README update for explanation of usage.
