### PR TITLE
Resolve issue where IE9/10/11 need a viewBox attribute to scale SVGs

### DIFF
--- a/lib/placeholder-image.js
+++ b/lib/placeholder-image.js
@@ -32,6 +32,9 @@ module.exports = function () {
 
         root.setAttribute('width', width);
         root.setAttribute('height', height);
+        
+        // for IE 9/10/11 scalability of SVGs
+        root.setAttribute('viewBox', '0 0 ' + width + ' ' + height);
 
         // Fill SVG with the pattern.
         var rect = new XMLNode('rect');


### PR DESCRIPTION
This article has info on the viewBox attr: https://css-tricks.com/scale-svg/ ... also: http://tympanus.net/Tutorials/ResponsiveSVGs/index4.html
