### PR TITLE
BSP-2609 - Sanitizes the Java package name generated based on a template's path.

### DIFF
--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
@@ -79,16 +79,13 @@ class TemplateDefinitions {
 
         StringBuilder javaPackageNameBuilder = new StringBuilder();
 
-        javaPackagePrefix = StringUtils.removeEnd(javaPackagePrefix, ".");
-        templatePath = StringUtils.ensureStart(templatePath.replaceAll("/", "."), ".");
+        String javaPackageSuffix = templatePath.replaceAll("/", ".");
 
-        char prev = '\0';
-        for (char c : (javaPackagePrefix + templatePath).toCharArray()) {
+        for (char c : (javaPackagePrefix + "." + javaPackageSuffix).replaceAll("\\.+", ".").toCharArray()) {
 
             // excludes characters that would be invalid in a java package name
-            if (Character.isJavaIdentifierPart(c) || (c == '.' && c != prev)) {
+            if (Character.isJavaIdentifierPart(c) || c == '.') {
                 javaPackageNameBuilder.append(c);
-                prev = c;
             }
         }
 

--- a/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
+++ b/viewgenerator/src/main/java/com/psddev/styleguide/TemplateDefinitions.java
@@ -59,7 +59,7 @@ class TemplateDefinitions {
                 namePath = name.substring(0, lastPathIndex);
             }
 
-            String javaPackageName = javaPackagePrefix + namePath.replaceAll("/", ".");
+            String javaPackageName = generateJavaPackageName(javaPackagePrefix, namePath);
 
             if (!mapTemplates.contains(name)) {
                 definitions.put(StringUtils.ensureStart(name, "/"), new TemplateDefinition(
@@ -71,6 +71,28 @@ class TemplateDefinitions {
                         javaClassNamePrefix));
             }
         });
+    }
+
+    // generates the package name for the template at the given path using
+    // the given prefix
+    private String generateJavaPackageName(String javaPackagePrefix, String templatePath) {
+
+        StringBuilder javaPackageNameBuilder = new StringBuilder();
+
+        javaPackagePrefix = StringUtils.removeEnd(javaPackagePrefix, ".");
+        templatePath = StringUtils.ensureStart(templatePath.replaceAll("/", "."), ".");
+
+        char prev = '\0';
+        for (char c : (javaPackagePrefix + templatePath).toCharArray()) {
+
+            // excludes characters that would be invalid in a java package name
+            if (Character.isJavaIdentifierPart(c) || (c == '.' && c != prev)) {
+                javaPackageNameBuilder.append(c);
+                prev = c;
+            }
+        }
+
+        return javaPackageNameBuilder.toString();
     }
 
     private void resolveAllTemplateFieldDefinitions() {


### PR DESCRIPTION
This fixes an issue where template paths like /foo/bar-baz/Qux.hbs used to resolve to a package of foo.bar-baz which is not a valid Java package name.
