### PR TITLE
Feature/bsp 2625/portable styleguide

### DIFF
--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -59,7 +59,7 @@ function resolveDataUrlPaths(data, currentDataPath, library) {
 }
 
 module.exports = function (config, req, res, context) {
-    var selectedLibrary = context.library;
+    var selectedLibrary = context.project;
     var filePath = selectedLibrary.findStyleguideFile(context.requestedPath + '.json');
 
     if (!filePath) {
@@ -98,18 +98,18 @@ module.exports = function (config, req, res, context) {
         }
     });
 
-    var projectLibrary = config.projectLibrary;
+    var project = config.project;
 
     // Wrap the example file data?
     if (data._wrapper !== false && !data._view) {
-        var wrapperPath = projectLibrary.findStyleguideFile(data._wrapper ? data._wrapper : '_wrapper.json');
+        var wrapperPath = project.findStyleguideFile(data._wrapper ? data._wrapper : '_wrapper.json');
 
         while (wrapperPath) {
             var wrapper = JSON.parse(fs.readFileSync(wrapperPath, 'utf8'));
 
-            resolveDataUrlPaths(wrapper, wrapperPath, projectLibrary);
+            resolveDataUrlPaths(wrapper, wrapperPath, project);
 
-            resolveTemplatePath(wrapper, projectLibrary);
+            resolveTemplatePath(wrapper, project);
 
             traverse(wrapper).forEach(function (value) {
                 if (value._delegate) {
@@ -119,7 +119,7 @@ module.exports = function (config, req, res, context) {
 
             data = wrapper;
 
-            wrapperPath = data._wrapper ? projectLibrary.findStyleguideFile(data._wrapper) : null;
+            wrapperPath = data._wrapper ? project.findStyleguideFile(data._wrapper) : null;
         }
     }
 
@@ -148,7 +148,7 @@ module.exports = function (config, req, res, context) {
                 logger.error('Partial deprecated: ' + templatePath);
 
                 if (!partialsRegistered) {
-                    projectLibrary.forEachProjectFile(function (filePath) {
+                    project.forEachProjectFile(function (filePath) {
                         if (filePath.indexOf('render') > -1) {
                             handlebars.registerPartial(
                                     'render/' + filePath.split('render')[1].split(/\/(.*)$/)[1].split('.hbs')[0],
@@ -171,7 +171,7 @@ module.exports = function (config, req, res, context) {
         var jsonData = {
             "json": JSON.stringify(removePrivateKeys(data), escapeHtml, 2)
         };
-        var jsonTemplate = fs.readFileSync(context.library.findStyleguideFile('/example-json.hbs'), 'utf8');
+        var jsonTemplate = fs.readFileSync(context.project.findStyleguideFile('/example-json.hbs'), 'utf8');
         var jsonCompiledTemplate = handlebars.compile(jsonTemplate);
 
         return jsonCompiledTemplate(jsonData);
@@ -199,7 +199,7 @@ module.exports = function (config, req, res, context) {
     });
 
     // Render the example file data.
-    var template = handlebars.compile(fs.readFileSync(projectLibrary.findStyleguideFile('/example-file.hbs'), 'utf8'));
+    var template = handlebars.compile(fs.readFileSync(project.findStyleguideFile('/example-file.hbs'), 'utf8'));
 
     function Template() {
     }

--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -9,12 +9,14 @@ var traverse = require('traverse');
 
 var DataGenerator = require('./data-generator');
 
-function resolveTemplatePath(data, library) {
+function resolveTemplatePath(data, requestPath, library) {
+    var relPath = path.dirname(requestPath);
+
     traverse(data).forEach(function (value) {
         var template = value._template;
 
         if (template) {
-            value._template = library.findFile(path.join.apply(path, template.split('/')) + '.hbs');
+            value._template = library.findFile(path.join.apply(path, template.split('/')) + '.hbs', relPath);
 
             if (!value._template) {
                 throw new Error(template + " template doesn't exist!");
@@ -72,7 +74,7 @@ module.exports = function (config, req, res, context) {
     resolveDataUrlPaths(data, filePath, selectedLibrary);
 
     // Resolve all _template paths.
-    resolveTemplatePath(data, selectedLibrary);
+    resolveTemplatePath(data, filePath, selectedLibrary);
 
     // Validate the JSON data. Exceptions for the special keys we have that are maps, so they don't need _template or _view
     traverse(data).forEach(function (value) {
@@ -109,7 +111,7 @@ module.exports = function (config, req, res, context) {
 
             resolveDataUrlPaths(wrapper, wrapperPath, project);
 
-            resolveTemplatePath(wrapper, project);
+            resolveTemplatePath(wrapper, wrapperPath, project);
 
             traverse(wrapper).forEach(function (value) {
                 if (value._delegate) {

--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -16,7 +16,8 @@ function resolveTemplatePath(data, requestPath, library) {
         var template = value._template;
 
         if (template) {
-            value._template = library.findFile(path.join.apply(path, template.split('/')) + '.hbs', relPath);
+            var extension = (path.extname(template).length <= 0) ? library._config['template-fallback-extension'] : '';
+            value._template = library.findFile(path.join.apply(path, template.split('/')) + extension, relPath);
 
             if (!value._template) {
                 throw new Error(template + " template doesn't exist!");
@@ -281,7 +282,8 @@ module.exports = function (config, req, res, context) {
     var DEFINE_BLOCK_CONTAINER_IN_EXTEND_DATA = DATA_PREFIX + 'defineBlockContainerInExtend';
 
     function compile(name) {
-        return handlebars.compile(fs.readFileSync(selectedLibrary.findFile(name + '.hbs'), 'utf8'));
+        var extension = (path.extname(name).length <= 0) ? config['template-fallback-extension'] : '';
+        return handlebars.compile(fs.readFileSync(selectedLibrary.findFile(name + extension), 'utf8'));
     }
 
     handlebars.registerHelper('defineBlock', function (name, options) {

--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -9,15 +9,15 @@ var traverse = require('traverse');
 
 var DataGenerator = require('./data-generator');
 
-function resolveTemplatePath(data, requestPath, library) {
+function resolveTemplatePath(data, requestPath, project) {
     var relPath = path.dirname(requestPath);
 
     traverse(data).forEach(function (value) {
         var template = value._template;
 
         if (template) {
-            var extension = (path.extname(template).length <= 0) ? library._config['template-fallback-extension'] : '';
-            value._template = library.findFile(path.join.apply(path, template.split('/')) + extension, relPath);
+            var extension = (path.extname(template).length <= 0) ? project._config['template-fallback-extension'] : '';
+            value._template = project.findFile(path.join.apply(path, template.split('/')) + extension, relPath);
 
             if (!value._template) {
                 throw new Error(template + " template doesn't exist!");
@@ -26,7 +26,7 @@ function resolveTemplatePath(data, requestPath, library) {
     });
 }
 
-function resolveDataUrlPaths(data, currentDataPath, library) {
+function resolveDataUrlPaths(data, currentDataPath, project) {
 
     traverse(data).forEach(function (value) {
         var dataUrl = value._dataUrl;
@@ -35,10 +35,10 @@ function resolveDataUrlPaths(data, currentDataPath, library) {
             var dataPath = path.join.apply(path, dataUrl.split('/'));
 
             if (dataUrl.slice(0, 1) === '/') {
-                dataPath = library.findStyleguideFile(dataPath);
+                dataPath = project.findStyleguideFile(dataPath);
 
                 if (!dataPath) {
-                    throw new Error("Can't find " + dataUrl + " in " + library.name + " styleguide!");
+                    throw new Error("Can't find " + dataUrl + " in " + project.name + " styleguide!");
                 }
 
             } else {
@@ -62,8 +62,8 @@ function resolveDataUrlPaths(data, currentDataPath, library) {
 }
 
 module.exports = function (config, req, res, context) {
-    var selectedLibrary = context.project;
-    var filePath = selectedLibrary.findStyleguideFile(context.requestedPath + '.json');
+    var selectedProject = context.project;
+    var filePath = selectedProject.findStyleguideFile(context.requestedPath + '.json');
 
     if (!filePath) {
         return false;
@@ -72,10 +72,10 @@ module.exports = function (config, req, res, context) {
     var data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
 
     // Resolve all _dataUrl paths
-    resolveDataUrlPaths(data, filePath, selectedLibrary);
+    resolveDataUrlPaths(data, filePath, selectedProject);
 
     // Resolve all _template paths.
-    resolveTemplatePath(data, filePath, selectedLibrary);
+    resolveTemplatePath(data, filePath, selectedProject);
 
     // Validate the JSON data. Exceptions for the special keys we have that are maps, so they don't need _template or _view
     traverse(data).forEach(function (value) {
@@ -283,7 +283,7 @@ module.exports = function (config, req, res, context) {
 
     function compile(name) {
         var extension = (path.extname(name).length <= 0) ? config['template-fallback-extension'] : '';
-        return handlebars.compile(fs.readFileSync(selectedLibrary.findFile(name + extension), 'utf8'));
+        return handlebars.compile(fs.readFileSync(selectedProject.findFile(name + extension), 'utf8'));
     }
 
     handlebars.registerHelper('defineBlock', function (name, options) {

--- a/lib/example-file.js
+++ b/lib/example-file.js
@@ -14,7 +14,7 @@ function resolveTemplatePath(data, library) {
         var template = value._template;
 
         if (template) {
-            value._template = library.findWebappFile(path.join.apply(path, template.split('/')) + '.hbs');
+            value._template = library.findFile(path.join.apply(path, template.split('/')) + '.hbs');
 
             if (!value._template) {
                 throw new Error(template + " template doesn't exist!");
@@ -148,7 +148,7 @@ module.exports = function (config, req, res, context) {
                 logger.error('Partial deprecated: ' + templatePath);
 
                 if (!partialsRegistered) {
-                    projectLibrary.forEachWebappFile(function (filePath) {
+                    projectLibrary.forEachProjectFile(function (filePath) {
                         if (filePath.indexOf('render') > -1) {
                             handlebars.registerPartial(
                                     'render/' + filePath.split('render')[1].split(/\/(.*)$/)[1].split('.hbs')[0],
@@ -279,7 +279,7 @@ module.exports = function (config, req, res, context) {
     var DEFINE_BLOCK_CONTAINER_IN_EXTEND_DATA = DATA_PREFIX + 'defineBlockContainerInExtend';
 
     function compile(name) {
-        return handlebars.compile(fs.readFileSync(selectedLibrary.findWebappFile(name + '.hbs'), 'utf8'));
+        return handlebars.compile(fs.readFileSync(selectedLibrary.findFile(name + '.hbs'), 'utf8'));
     }
 
     handlebars.registerHelper('defineBlock', function (name, options) {

--- a/lib/library.js
+++ b/lib/library.js
@@ -13,17 +13,18 @@ function Library(config, projectPath) {
     this._config = config;
     this.name = label(path.basename(path.resolve(projectPath)));
 
-    if (this._config.v4) {
-        var projectSrcPath = config['project-src-path']
-        if (projectSrcPath) {
-            projectSrcPath = path.join(projectPath, config['project-src-path']);
-        }
+    // is the project running with a styleguide directory separate from the source directory?
+    if (!this._config.v4) {
+        this._styleguidePath = path.join(config['project-path'], config['styleguide-path'])
     }
-    else {
-        var projectSrcPath = config['styleguide-path']
-        if (projectSrcPath) {
-            projectSrcPath = path.join(projectPath, config['styleguide-path']);
-        }
+
+    if (fs.existsSync(projectPath)) {
+        this._projectPath = projectPath;
+    }
+
+    var projectSrcPath = config['project-src-path']
+    if (projectSrcPath) {
+        projectSrcPath = path.join(this._projectPath, config['project-src-path']);
     }
 
     if (fs.existsSync(projectSrcPath) && fs.statSync(projectSrcPath).isDirectory()) {
@@ -44,12 +45,6 @@ function Library(config, projectPath) {
             });
         }
     }
-
-    var projectPath = path.join(projectPath, config['project-src-path']);
-
-    if (fs.existsSync(projectPath)) {
-        this._projectPath = projectPath;
-    }
 }
 
 // Returns the merged Library specific config (if it exists) onto the provided config object
@@ -64,22 +59,37 @@ Library.prototype.mergeConfig = function (config) {
     return config;
 };
 
+
+Library.prototype.getConfigPath = function () {
+    var configName = this._config['config-file-name']
+    var filePath
+
+    // prefer the config in the source path
+    filePath = path.join(this._projectSrcPath, configName)
+    if (fs.existsSync(filePath)) {
+        return filePath
+    }
+
+    // fallback on the styleguide path
+    filePath = path.join(this._styleguidePath, configName)
+    if (fs.existsSync(filePath)) {
+        return filePath
+    }
+};
+
 // Returns the Library specific config data
 Library.prototype.getConfig = function () {
+    var filePath = this.getConfigPath()
     try {
-        return JSON.parse(fs.readFileSync(path.join(this._projectSrcPath, '_config.json'), "utf8"));
+        return JSON.parse(fs.readFileSync(filePath, "utf8"));
     } catch (ex) {
+        logger.warn("Project config file was unable to be parsed");
         return null;
     }
 };
 
 Library.prototype.isLibrary = function () {
-    if (this._config.v4) {
-        return true
-    }
-    else {
-        return this._projectSrcPath || this._projectPath;
-    }
+    return this._projectSrcPath || this._projectPath;
 };
 
 Library.prototype.forEachPath = function (callback) {
@@ -97,7 +107,7 @@ Library.prototype.forEachPath = function (callback) {
 };
 
 Library.prototype.forEachStyleguideGroup = function (callback) {
-    var projectSrcPath = this._projectSrcPath;
+    var projectSrcPath = this._styleguidePath || this._projectSrcPath;
 
     function excludeFilter(group) {
         if (group.slice(0, 1) === '_'
@@ -119,7 +129,6 @@ Library.prototype.forEachStyleguideGroup = function (callback) {
 };
 
 Library.prototype.forEachProjectFile = function (callback) {
-debugger
     var seen = { };
     var projectPath = this._projectPath;
 
@@ -142,16 +151,26 @@ debugger
     }
 };
 
-// prefers the file to be resolved in the styleguide directory, with a fallback on the basepath
-Library.prototype.findFile = function (file) {
-    return this.findStyleguideFile(file) || this.findAppFile(file);
+Library.prototype.findFile = function (file, relPath) {
+    // can we resolve the file using the relative path?
+    if (relPath) {
+        var filePath = path.resolve(relPath, file);
+        if (fs.existsSync(filePath)) {
+            return filePath;
+        }
+    }
+
+    // go look elsewhere
+    return this.findStyleguideFile(file) || this.findProjectFile(file);
 }
 
+// for backwards compatability where the styleguide files live outside the sourcePath
 Library.prototype.findStyleguideFile = function (file) {
     var filePath;
+    var styleguidePath = this._styleguidePath || this._projectSrcPath;
 
-    if (this._projectSrcPath) {
-        filePath = path.join(this._projectSrcPath, file);
+    if (styleguidePath) {
+        filePath = path.join(styleguidePath, file);
 
         if (fs.existsSync(filePath)) {
             return filePath;
@@ -167,7 +186,7 @@ Library.prototype.findStyleguideFile = function (file) {
     return null;
 };
 
-Library.prototype.findAppFile = function (file) {
+Library.prototype.findProjectFile = function (file) {
     function find(projectPath) {
         if (projectPath) {
             filePath = path.join(projectPath, file);
@@ -187,10 +206,10 @@ Library.prototype.findVariableFiles = function () {
 
     // Find all variable files.
     var varFiles = [ ];
-    var projectPath = this._projectPath;
+    var projectSrcPath = this._projectSrcPath;
 
-    if (projectPath) {
-        rrs(projectPath).forEach(function (filePath) {
+    if (projectSrcPath) {
+        rrs(projectSrcPath).forEach(function (filePath) {
             if (path.extname(filePath) === '.vars') {
                 varFiles.push({
                     path: filePath,

--- a/lib/library.js
+++ b/lib/library.js
@@ -55,13 +55,13 @@ Library.prototype.mergeConfig = function (config) {
         return _.extend({ }, config, cfg);
     }
     logger.success('Configured with default "_config.json" file');
-    logger.warn('(You can override this by creating a config file within your project\'s styleguide)');
+    logger.warn('(You can override this by creating an "_config.json" file within your project\'s styleguide)');
     return config;
 };
 
 
 Library.prototype.getConfigPath = function () {
-    var configName = this._config['config-file-name']
+    var configName = "_config.json"
     var filePath
 
     // prefer the config in the source path

--- a/lib/library.js
+++ b/lib/library.js
@@ -7,34 +7,36 @@ var parseString = require('xml2js').parseString;
 var logger = require('./logger');
 var label = require('./label');
 
-function Library(config, projectRoot) {
+function Library(config, projectPath) {
     var self = this;
 
     this._config = config;
-    this.name = label(path.basename(path.resolve(projectRoot)));
+    this.name = label(path.basename(path.resolve(projectPath)));
 
     if (this._config.v4) {
-        var styleguidePath = '.'
+        var projectSrcPath = config['project-src-path']
+        if (projectSrcPath) {
+            projectSrcPath = path.join(projectPath, config['project-src-path']);
+        }
     }
     else {
-        var styleguidePath = config['styleguide-path']
-        // backwards-compat: When the styleguide is a child of the basepath
-        if (styleguidePath) {
-            styleguidePath = path.join(projectRoot, config['styleguide-path']);
+        var projectSrcPath = config['styleguide-path']
+        if (projectSrcPath) {
+            projectSrcPath = path.join(projectPath, config['styleguide-path']);
         }
     }
 
-    if (fs.existsSync(styleguidePath) && fs.statSync(styleguidePath).isDirectory()) {
-        this._styleguidePath = styleguidePath;
+    if (fs.existsSync(projectSrcPath) && fs.statSync(projectSrcPath).isDirectory()) {
+        this._projectSrcPath = projectSrcPath;
     }
 
-    if (config['project-path'] === projectRoot) {
-        var pomPath = path.join(projectRoot, config['maven-pom']);
+    if (config['project-path'] === projectPath) {
+        var pomPath = path.join(projectPath, config['maven-pom']);
 
         if (fs.existsSync(pomPath)) {
             parseString(fs.readFileSync(pomPath), { async: false }, function (err, pomXml) {
                 var targetName = pomXml.project.artifactId + '-' + pomXml.project.version;
-                var targetPath = path.join(projectRoot, 'target', targetName);
+                var targetPath = path.join(projectPath, 'target', targetName);
 
                 if (fs.existsSync(targetPath)) {
                     self._targetPath = targetPath;
@@ -43,10 +45,10 @@ function Library(config, projectRoot) {
         }
     }
 
-    var projectRoot = path.join(projectRoot, config['project-src-path']);
+    var projectPath = path.join(projectPath, config['project-src-path']);
 
-    if (fs.existsSync(projectRoot)) {
-        this._projectRoot = projectRoot;
+    if (fs.existsSync(projectPath)) {
+        this._projectPath = projectPath;
     }
 }
 
@@ -54,7 +56,7 @@ function Library(config, projectRoot) {
 Library.prototype.mergeConfig = function (config) {
     var cfg = this.getConfig();
     if (cfg){
-        logger.success('Configured with: '+ path.join(this._styleguidePath, '_config.json'));
+        logger.success('Configured with: '+ path.join(this._projectSrcPath, '_config.json'));
         return _.extend({ }, config, cfg);
     }
     logger.success('Configured with default "_config.json" file');
@@ -65,7 +67,7 @@ Library.prototype.mergeConfig = function (config) {
 // Returns the Library specific config data
 Library.prototype.getConfig = function () {
     try {
-        return JSON.parse(fs.readFileSync(path.join(this._styleguidePath, '_config.json'), "utf8"));
+        return JSON.parse(fs.readFileSync(path.join(this._projectSrcPath, '_config.json'), "utf8"));
     } catch (ex) {
         return null;
     }
@@ -76,26 +78,26 @@ Library.prototype.isLibrary = function () {
         return true
     }
     else {
-        return this._styleguidePath || this._projectRoot;
+        return this._projectSrcPath || this._projectPath;
     }
 };
 
 Library.prototype.forEachPath = function (callback) {
-    if (this._styleguidePath) {
-        callback(this._styleguidePath);
+    if (this._projectSrcPath) {
+        callback(this._projectSrcPath);
     }
 
     if (this._targetPath) {
         callback(this._targetPath);
     }
 
-    if (this._projectRoot) {
-        callback(this._projectRoot);
+    if (this._projectPath) {
+        callback(this._projectPath);
     }
 };
 
 Library.prototype.forEachStyleguideGroup = function (callback) {
-    var styleguidePath = this._styleguidePath;
+    var projectSrcPath = this._projectSrcPath;
 
     function excludeFilter(group) {
         if (group.slice(0, 1) === '_'
@@ -106,9 +108,9 @@ Library.prototype.forEachStyleguideGroup = function (callback) {
         return true
     }
 
-    if (styleguidePath) {
-        fs.readdirSync(styleguidePath).filter(excludeFilter).forEach(function (group) {
-            var groupPath = path.join(styleguidePath, group);
+    if (projectSrcPath) {
+        fs.readdirSync(projectSrcPath).filter(excludeFilter).forEach(function (group) {
+            var groupPath = path.join(projectSrcPath, group);
             if (fs.statSync(groupPath).isDirectory()) {
                 callback(group, groupPath);
             }
@@ -117,12 +119,13 @@ Library.prototype.forEachStyleguideGroup = function (callback) {
 };
 
 Library.prototype.forEachProjectFile = function (callback) {
+debugger
     var seen = { };
-    var projectRoot = this._projectRoot;
+    var projectPath = this._projectPath;
 
-    if (projectRoot) {
-        rrs(projectRoot).forEach(function (filePath) {
-            seen[path.relative(projectRoot, filePath)] = true;
+    if (projectPath) {
+        rrs(projectPath).forEach(function (filePath) {
+            seen[path.relative(projectPath, filePath)] = true;
 
             callback(filePath);
         });
@@ -147,8 +150,8 @@ Library.prototype.findFile = function (file) {
 Library.prototype.findStyleguideFile = function (file) {
     var filePath;
 
-    if (this._styleguidePath) {
-        filePath = path.join(this._styleguidePath, file);
+    if (this._projectSrcPath) {
+        filePath = path.join(this._projectSrcPath, file);
 
         if (fs.existsSync(filePath)) {
             return filePath;
@@ -165,9 +168,9 @@ Library.prototype.findStyleguideFile = function (file) {
 };
 
 Library.prototype.findAppFile = function (file) {
-    function find(projectRoot) {
-        if (projectRoot) {
-            filePath = path.join(projectRoot, file);
+    function find(projectPath) {
+        if (projectPath) {
+            filePath = path.join(projectPath, file);
 
             if (fs.existsSync(filePath)) {
                 return filePath;
@@ -177,17 +180,17 @@ Library.prototype.findAppFile = function (file) {
         return null;
     }
 
-    return find(this._projectRoot) || find(this._targetPath);
+    return find(this._projectPath) || find(this._targetPath);
 };
 
 Library.prototype.findVariableFiles = function () {
 
     // Find all variable files.
     var varFiles = [ ];
-    var projectRoot = this._projectRoot;
+    var projectPath = this._projectPath;
 
-    if (projectRoot) {
-        rrs(projectRoot).forEach(function (filePath) {
+    if (projectPath) {
+        rrs(projectPath).forEach(function (filePath) {
             if (path.extname(filePath) === '.vars') {
                 varFiles.push({
                     path: filePath,

--- a/lib/library.js
+++ b/lib/library.js
@@ -7,25 +7,34 @@ var parseString = require('xml2js').parseString;
 var logger = require('./logger');
 var label = require('./label');
 
-function Library(config, basePath) {
+function Library(config, projectRoot) {
     var self = this;
 
     this._config = config;
-    this.name = label(path.basename(path.resolve(basePath)));
+    this.name = label(path.basename(path.resolve(projectRoot)));
 
-    var styleguidePath = path.join(basePath, config['styleguide-path']);
+    if (this._config.v4) {
+        var styleguidePath = '.'
+    }
+    else {
+        var styleguidePath = config['styleguide-path']
+        // backwards-compat: When the styleguide is a child of the basepath
+        if (styleguidePath) {
+            styleguidePath = path.join(projectRoot, config['styleguide-path']);
+        }
+    }
 
     if (fs.existsSync(styleguidePath) && fs.statSync(styleguidePath).isDirectory()) {
         this._styleguidePath = styleguidePath;
     }
 
-    if (config['project-path'] === basePath) {
-        var pomPath = path.join(basePath, config['maven-pom']);
+    if (config['project-path'] === projectRoot) {
+        var pomPath = path.join(projectRoot, config['maven-pom']);
 
         if (fs.existsSync(pomPath)) {
             parseString(fs.readFileSync(pomPath), { async: false }, function (err, pomXml) {
                 var targetName = pomXml.project.artifactId + '-' + pomXml.project.version;
-                var targetPath = path.join(basePath, 'target', targetName);
+                var targetPath = path.join(projectRoot, 'target', targetName);
 
                 if (fs.existsSync(targetPath)) {
                     self._targetPath = targetPath;
@@ -34,10 +43,10 @@ function Library(config, basePath) {
         }
     }
 
-    var webappPath = path.join(basePath, config['maven-webapp-path']);
+    var projectRoot = path.join(projectRoot, config['project-src-path']);
 
-    if (fs.existsSync(webappPath)) {
-        this._webappPath = webappPath;
+    if (fs.existsSync(projectRoot)) {
+        this._projectRoot = projectRoot;
     }
 }
 
@@ -63,7 +72,12 @@ Library.prototype.getConfig = function () {
 };
 
 Library.prototype.isLibrary = function () {
-    return this._styleguidePath || this._webappPath;
+    if (this._config.v4) {
+        return true
+    }
+    else {
+        return this._styleguidePath || this._projectRoot;
+    }
 };
 
 Library.prototype.forEachPath = function (callback) {
@@ -75,34 +89,40 @@ Library.prototype.forEachPath = function (callback) {
         callback(this._targetPath);
     }
 
-    if (this._webappPath) {
-        callback(this._webappPath);
+    if (this._projectRoot) {
+        callback(this._projectRoot);
     }
 };
 
 Library.prototype.forEachStyleguideGroup = function (callback) {
     var styleguidePath = this._styleguidePath;
 
-    if (styleguidePath) {
-        fs.readdirSync(styleguidePath).forEach(function (group) {
-            if (group.slice(0, 1) !== '_') {
-                var groupPath = path.join(styleguidePath, group);
+    function excludeFilter(group) {
+        if (group.slice(0, 1) === '_'
+            || group === 'bower_components'
+            || group === 'node_modules') {
+            return false
+        }
+        return true
+    }
 
-                if (fs.statSync(groupPath).isDirectory()) {
-                    callback(group, groupPath);
-                }
+    if (styleguidePath) {
+        fs.readdirSync(styleguidePath).filter(excludeFilter).forEach(function (group) {
+            var groupPath = path.join(styleguidePath, group);
+            if (fs.statSync(groupPath).isDirectory()) {
+                callback(group, groupPath);
             }
         });
     }
 };
 
-Library.prototype.forEachWebappFile = function (callback) {
+Library.prototype.forEachProjectFile = function (callback) {
     var seen = { };
-    var webappPath = this._webappPath;
+    var projectRoot = this._projectRoot;
 
-    if (webappPath) {
-        rrs(webappPath).forEach(function (filePath) {
-            seen[path.relative(webappPath, filePath)] = true;
+    if (projectRoot) {
+        rrs(projectRoot).forEach(function (filePath) {
+            seen[path.relative(projectRoot, filePath)] = true;
 
             callback(filePath);
         });
@@ -118,6 +138,11 @@ Library.prototype.forEachWebappFile = function (callback) {
         });
     }
 };
+
+// prefers the file to be resolved in the styleguide directory, with a fallback on the basepath
+Library.prototype.findFile = function (file) {
+    return this.findStyleguideFile(file) || this.findAppFile(file);
+}
 
 Library.prototype.findStyleguideFile = function (file) {
     var filePath;
@@ -139,10 +164,10 @@ Library.prototype.findStyleguideFile = function (file) {
     return null;
 };
 
-Library.prototype.findWebappFile = function (file) {
-    function find(basePath) {
-        if (basePath) {
-            filePath = path.join(basePath, file);
+Library.prototype.findAppFile = function (file) {
+    function find(projectRoot) {
+        if (projectRoot) {
+            filePath = path.join(projectRoot, file);
 
             if (fs.existsSync(filePath)) {
                 return filePath;
@@ -152,17 +177,17 @@ Library.prototype.findWebappFile = function (file) {
         return null;
     }
 
-    return find(this._webappPath) || find(this._targetPath);
+    return find(this._projectRoot) || find(this._targetPath);
 };
 
 Library.prototype.findVariableFiles = function () {
 
     // Find all variable files.
     var varFiles = [ ];
-    var webappPath = this._webappPath;
+    var projectRoot = this._projectRoot;
 
-    if (webappPath) {
-        rrs(webappPath).forEach(function (filePath) {
+    if (projectRoot) {
+        rrs(projectRoot).forEach(function (filePath) {
             if (path.extname(filePath) === '.vars') {
                 varFiles.push({
                     path: filePath,

--- a/lib/project.js
+++ b/lib/project.js
@@ -55,10 +55,17 @@ function Project(config, projectPath) {
 // Returns the merged Project specific config (if it exists) onto the provided config object
 Project.prototype.mergeConfig = function (config) {
     var cfg = this.getConfig();
+    var filePath = this._projectSrcPath;
+
+    if (this._config['legacy-project']){
+        filePath = this._styleguidePath
+    }
+
     if (cfg){
-        logger.success('Configured with: '+ path.join(this._projectSrcPath, '_config.json'));
+        logger.success('Configured with: '+ path.join(filePath, '_config.json'));
         return _.extend({ }, config, cfg);
     }
+
     logger.success('Configured with default "_config.json" file');
     logger.warn('(You can override this by creating an "_config.json" file within your project\'s styleguide)');
     return config;

--- a/lib/project.js
+++ b/lib/project.js
@@ -13,13 +13,18 @@ function Project(config, projectPath) {
     this._config = config;
     this.name = label(path.basename(path.resolve(projectPath)));
 
-    // is the project running with a styleguide directory separate from the source directory?
-    if (!this._config.v4) {
-        this._styleguidePath = path.join(config['project-path'], config['styleguide-path'])
-    }
-
     if (fs.existsSync(projectPath)) {
         this._projectPath = projectPath;
+    }
+
+    // Project has a 'styleguide' directory?
+    if (fs.existsSync(path.join(this._projectPath, 'styleguide'))) {
+        this._config['legacy-project'] = true;
+    }
+
+    // Legacy projects define a separate path for their styleguide
+    if (this._config['legacy-project']) {
+        this._styleguidePath = path.join(config['project-path'], config['styleguide-path'])
     }
 
     var projectSrcPath = config['project-src-path']

--- a/lib/project.js
+++ b/lib/project.js
@@ -7,7 +7,7 @@ var parseString = require('xml2js').parseString;
 var logger = require('./logger');
 var label = require('./label');
 
-function Library(config, projectPath) {
+function Project(config, projectPath) {
     var self = this;
 
     this._config = config;
@@ -47,8 +47,8 @@ function Library(config, projectPath) {
     }
 }
 
-// Returns the merged Library specific config (if it exists) onto the provided config object
-Library.prototype.mergeConfig = function (config) {
+// Returns the merged Project specific config (if it exists) onto the provided config object
+Project.prototype.mergeConfig = function (config) {
     var cfg = this.getConfig();
     if (cfg){
         logger.success('Configured with: '+ path.join(this._projectSrcPath, '_config.json'));
@@ -60,7 +60,7 @@ Library.prototype.mergeConfig = function (config) {
 };
 
 
-Library.prototype.getConfigPath = function () {
+Project.prototype.getConfigPath = function () {
     var configName = "_config.json"
     var filePath
 
@@ -77,8 +77,8 @@ Library.prototype.getConfigPath = function () {
     }
 };
 
-// Returns the Library specific config data
-Library.prototype.getConfig = function () {
+// Returns the Project specific config data
+Project.prototype.getConfig = function () {
     var filePath = this.getConfigPath()
     try {
         return JSON.parse(fs.readFileSync(filePath, "utf8"));
@@ -88,11 +88,11 @@ Library.prototype.getConfig = function () {
     }
 };
 
-Library.prototype.isLibrary = function () {
+Project.prototype.isProject = function () {
     return this._projectSrcPath || this._projectPath;
 };
 
-Library.prototype.forEachPath = function (callback) {
+Project.prototype.forEachPath = function (callback) {
     if (this._projectSrcPath) {
         callback(this._projectSrcPath);
     }
@@ -106,7 +106,7 @@ Library.prototype.forEachPath = function (callback) {
     }
 };
 
-Library.prototype.forEachStyleguideGroup = function (callback) {
+Project.prototype.forEachStyleguideGroup = function (callback) {
     var projectSrcPath = this._styleguidePath || this._projectSrcPath;
 
     function excludeFilter(group) {
@@ -128,7 +128,7 @@ Library.prototype.forEachStyleguideGroup = function (callback) {
     }
 };
 
-Library.prototype.forEachProjectFile = function (callback) {
+Project.prototype.forEachProjectFile = function (callback) {
     var seen = { };
     var projectPath = this._projectPath;
 
@@ -151,7 +151,7 @@ Library.prototype.forEachProjectFile = function (callback) {
     }
 };
 
-Library.prototype.findFile = function (file, relPath) {
+Project.prototype.findFile = function (file, relPath) {
     // can we resolve the file using the relative path?
     if (relPath) {
         var filePath = path.resolve(relPath, file);
@@ -165,7 +165,7 @@ Library.prototype.findFile = function (file, relPath) {
 }
 
 // for backwards compatability where the styleguide files live outside the sourcePath
-Library.prototype.findStyleguideFile = function (file) {
+Project.prototype.findStyleguideFile = function (file) {
     var filePath;
     var styleguidePath = this._styleguidePath || this._projectSrcPath;
 
@@ -186,7 +186,7 @@ Library.prototype.findStyleguideFile = function (file) {
     return null;
 };
 
-Library.prototype.findProjectFile = function (file) {
+Project.prototype.findProjectFile = function (file) {
     function find(projectPath) {
         if (projectPath) {
             filePath = path.join(projectPath, file);
@@ -202,7 +202,7 @@ Library.prototype.findProjectFile = function (file) {
     return find(this._projectPath) || find(this._targetPath);
 };
 
-Library.prototype.findVariableFiles = function () {
+Project.prototype.findVariableFiles = function () {
 
     // Find all variable files.
     var varFiles = [ ];
@@ -249,4 +249,4 @@ Library.prototype.findVariableFiles = function () {
     return varFiles;
 };
 
-module.exports = Library;
+module.exports = Project;

--- a/lib/render-page.js
+++ b/lib/render-page.js
@@ -3,7 +3,7 @@ var handlebars = require('handlebars');
 var _ = require('lodash');
 
 function read(context, filePath) {
-    return fs.readFileSync(context.library.findStyleguideFile(filePath), 'utf8');
+    return fs.readFileSync(context.project.findStyleguideFile(filePath), 'utf8');
 }
 
 module.exports = function (config, context, templatePath) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,13 +26,15 @@ var defaults = {
 };
 
 module.exports = function (config) {
+    config = _.extend({ }, defaults, config);
+
     logger.welcome();
 
     var app = express();
 
-    // Save API endpoint.
     app.use(bodyParser.urlencoded({ extended: true }));
 
+    // API endpoint for Saving
     app.post('/save', function (req, res, next) {
         fs.writeFileSync(req.body.path, req.body.data, 'utf8');
 
@@ -65,15 +67,13 @@ module.exports = function (config) {
         fonts: [ require("connect-fonts-opensans") ]
     }));
 
-    config = _.extend({ }, defaults, config);
-
     var project = config.project = new Library(config, config['project-path'])
 
     if (project.isLibrary()) {
         project.urlPrefix = '/' + project.name.replace(/ /g, '-').toLowerCase();
     }
 
-    // merge any project specific library configs overtop the current config
+    // merge any project specific configs overtop the current config
     config = project.mergeConfig(config);
 
     logger.success('Project: ' + project.name);

--- a/lib/server.js
+++ b/lib/server.js
@@ -67,31 +67,17 @@ module.exports = function (config) {
 
     config = _.extend({ }, defaults, config);
 
-    logger.success('Project Path: ' + config['project-path']);
+    var project = config.project = new Library(config, config['project-path'])
 
-    // Find all libraries.
-    var libraries = config.libraries = [ ];
-
-    function addLibrary(basePath) {
-        var library = new Library(config, basePath);
-
-        if (library.isLibrary()) {
-            library.urlPrefix = '/' + library.name.replace(/ /g, '-').toLowerCase();
-
-            libraries.push(library);
-        }
-
-        return library;
+    if (project.isLibrary()) {
+        project.urlPrefix = '/' + project.name.replace(/ /g, '-').toLowerCase();
     }
 
-    var projectLibrary = config.projectLibrary = addLibrary(config['project-path']);
-
     // merge any project specific library configs overtop the current config
-    config = projectLibrary.mergeConfig(config);
+    config = project.mergeConfig(config);
 
-    libraries.forEach(function (library) {
-        logger.success('Library: ' + library.name);
-    });
+    logger.success('Project: ' + project.name);
+    logger.success('Project Path: ' + config['project-path']);
 
     // Main display.
     app.use(function (req, res, next) {
@@ -100,33 +86,15 @@ module.exports = function (config) {
         // Seed for the randomization.
         var seed = context.seed = parseInt(req.query.seed, 10) || Math.floor(Math.random() * 1000000);
 
-        // Selected library?
-        var availableLibraries = context.availableLibraries = [ ];
-        var library;
-
-        config.libraries.forEach(function (l) {
-            var al = { library: l };
-
-            availableLibraries.push(al);
-
-            if (req.url.indexOf(l.urlPrefix) === 0) {
-                library = l;
-                al.selected = true;
-            }
-        });
-
-        if (!library) {
-            library = libraries[0];
-        }
-
-        context.library = library;
+        context.project = project;
 
         // Request URL (e.g. /foo/bar) to file path (e.g. \foo\bar in Windows).
         var requestedUrl = req.path;
+
         // Is this request pathed under the library prefix?
-        if (requestedUrl.indexOf(library.urlPrefix) > -1){
-            // strip the library path off
-            requestedUrl = req.path.slice(library.urlPrefix.length);
+        if (requestedUrl.indexOf(project.urlPrefix) > -1){
+            // strip the project path off
+            requestedUrl = req.path.slice(project.urlPrefix.length);
         }
 
         context.requestedUrl = requestedUrl;
@@ -163,7 +131,7 @@ module.exports = function (config) {
         var originalUrlSearch = url.parse(req.originalUrl).search || '';
 
         // Any variable files?
-        var varFiles = library.findVariableFiles();
+        var varFiles = project.findVariableFiles();
 
         if (varFiles.length > 0) {
             var varExamples = [ ];
@@ -177,13 +145,13 @@ module.exports = function (config) {
             varFiles.forEach(function (varFile) {
                 varExamples.push({
                     name: varFile.name.split('/').map(function (n) { return label(n); }).join(': '),
-                    url: library.urlPrefix + '/variables/' + varFile.name
+                    url: project.urlPrefix + '/variables/' + varFile.name
                 });
             });
         }
 
         // Finds all groups of examples in the styleguide directory.
-        library.forEachStyleguideGroup(function (group, groupPath) {
+        project.forEachStyleguideGroup(function (group, groupPath) {
             var examples = [ ];
 
             // Finds all examples in this group.
@@ -194,7 +162,7 @@ module.exports = function (config) {
                     if (fs.statSync(examplePath).isDirectory()) {
                         examples.push({
                             name: label(example),
-                            url: library.urlPrefix + '/' + group + '/' + example + originalUrlSearch
+                            url: project.urlPrefix + '/' + group + '/' + example + originalUrlSearch
                         });
                     }
                 }
@@ -279,7 +247,7 @@ module.exports = function (config) {
         }
 
         // Example directory with JSON data files within?
-        var examplePath = library.findStyleguideFile(requestedPath);
+        var examplePath = project.findStyleguideFile(requestedPath);
 
         if (!examplePath || !fs.statSync(examplePath).isDirectory()) {
             next();
@@ -358,14 +326,9 @@ module.exports = function (config) {
 
     app.use('/node-modules', express.static(path.join(__dirname, '..', 'node_modules')));
 
-    projectLibrary.forEachPath(function (libraryPath) {
+    project.forEachPath(function (libraryPath) {
         app.use(express.static(libraryPath));
-    });
-
-    libraries.forEach(function (library) {
-        library.forEachPath(function (libraryPath) {
-            app.use(library.urlPrefix, express.static(libraryPath));
-        });
+        app.use(project.urlPrefix, express.static(libraryPath));
     });
 
     // Load project-specific middleware

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,7 +23,8 @@ var defaults = {
     'json-suffix': '.json',
     'maven-pom': 'pom.xml',
     'maven-webapp-path': path.join('src', 'main', 'webapp'),
-    'template-fallback-extension': '.hbs'
+    'template-fallback-extension': '.hbs',
+    'legacy-project': false
 };
 
 module.exports = function (config) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,7 +23,8 @@ var defaults = {
     'json-suffix': '.json',
     'maven-pom': 'pom.xml',
     'maven-webapp-path': path.join('src', 'main', 'webapp'),
-    'config-file-name': '_config.json'
+    'config-file-name': '_config.json',
+    'template-fallback-extension': '.hbs'
 };
 
 module.exports = function (config) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -18,9 +18,9 @@ var renderPage = require('./render-page');
 
 var defaults = {
     'project-path': '.',
+    'project-src-path': path.join('src', 'main', 'webapp'),
     'styleguide-path': 'styleguide',
     'json-suffix': '.json',
-
     'maven-pom': 'pom.xml',
     'maven-webapp-path': path.join('src', 'main', 'webapp')
 };
@@ -84,20 +84,10 @@ module.exports = function (config) {
         return library;
     }
 
-    function addChildLibraries(parentPath) {
-        if (fs.existsSync(parentPath)) {
-            fs.readdirSync(parentPath).forEach(function (child) {
-                addLibrary(path.join(parentPath, child));
-            });
-        }
-    }
-
     var projectLibrary = config.projectLibrary = addLibrary(config['project-path']);
 
     // merge any project specific library configs overtop the current config
     config = projectLibrary.mergeConfig(config);
-
-    addChildLibraries(path.join(config['project-path'], 'bower_components'));
 
     libraries.forEach(function (library) {
         logger.success('Library: ' + library.name);

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,7 +22,8 @@ var defaults = {
     'styleguide-path': 'styleguide',
     'json-suffix': '.json',
     'maven-pom': 'pom.xml',
-    'maven-webapp-path': path.join('src', 'main', 'webapp')
+    'maven-webapp-path': path.join('src', 'main', 'webapp'),
+    'config-file-name': '_config.json'
 };
 
 module.exports = function (config) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,7 @@ var url = require('url');
 var querystring = require('querystring');
 
 var label = require('./label');
-var Library = require('./library');
+var Project = require('./project');
 var logger = require('./logger');
 var renderPage = require('./render-page');
 
@@ -68,9 +68,9 @@ module.exports = function (config) {
         fonts: [ require("connect-fonts-opensans") ]
     }));
 
-    var project = config.project = new Library(config, config['project-path'])
+    var project = config.project = new Project(config, config['project-path'])
 
-    if (project.isLibrary()) {
+    if (project.isProject()) {
         project.urlPrefix = '/' + project.name.replace(/ /g, '-').toLowerCase();
     }
 
@@ -92,7 +92,7 @@ module.exports = function (config) {
         // Request URL (e.g. /foo/bar) to file path (e.g. \foo\bar in Windows).
         var requestedUrl = req.path;
 
-        // Is this request pathed under the library prefix?
+        // Is this request pathed under the project prefix?
         if (requestedUrl.indexOf(project.urlPrefix) > -1){
             // strip the project path off
             requestedUrl = req.path.slice(project.urlPrefix.length);
@@ -327,9 +327,9 @@ module.exports = function (config) {
 
     app.use('/node-modules', express.static(path.join(__dirname, '..', 'node_modules')));
 
-    project.forEachPath(function (libraryPath) {
-        app.use(express.static(libraryPath));
-        app.use(project.urlPrefix, express.static(libraryPath));
+    project.forEachPath(function (projectPath) {
+        app.use(express.static(projectPath));
+        app.use(project.urlPrefix, express.static(projectPath));
     });
 
     // Load project-specific middleware

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,7 +23,6 @@ var defaults = {
     'json-suffix': '.json',
     'maven-pom': 'pom.xml',
     'maven-webapp-path': path.join('src', 'main', 'webapp'),
-    'config-file-name': '_config.json',
     'template-fallback-extension': '.hbs'
 };
 

--- a/lib/variables.js
+++ b/lib/variables.js
@@ -19,7 +19,7 @@ module.exports = function render(config, req, res, context) {
     var name = match[1];
     var selectedFilePath;
 
-    context.library.findVariableFiles().forEach(function (varFile) {
+    context.project.findVariableFiles().forEach(function (varFile) {
         if (varFile.name === name) {
             selectedFilePath = varFile.path;
         }
@@ -37,10 +37,10 @@ module.exports = function render(config, req, res, context) {
     }
 
     Variable.prototype.toHTML = function () {
-        var templatePath = context.library.findStyleguideFile(path.join('variables', this.type + '.hbs'));
+        var templatePath = context.project.findStyleguideFile(path.join('variables', this.type + '.hbs'));
 
         if (!templatePath) {
-            templatePath = context.library.findStyleguideFile(path.join('variables', 'default.hbs'));
+            templatePath = context.project.findStyleguideFile(path.join('variables', 'default.hbs'));
         }
 
         var template = fs.readFileSync(templatePath, 'utf8');

--- a/styleguide.js
+++ b/styleguide.js
@@ -1,0 +1,35 @@
+var path = require('path');
+var fs = require('fs');
+
+var Styleguide = function(config) {
+    var config = config || {};
+
+    process.title = config.title || 'styleguide';
+
+    if (config.daemon) {
+        require('daemon')();
+    }
+
+    if (config._ && config._.length > 0) {
+        config['project-path'] = config._[0];
+    }
+
+    var configFile = fs.readFileSync(path.join(__dirname, 'styleguide', '_config.json'), "utf8");
+
+    // Merge the command line args onto the _config file
+    this.config = Object.assign({ }, JSON.parse(configFile), config);
+}
+
+Styleguide.prototype.srcPath = function() {
+    return 'src'
+};
+
+Styleguide.prototype.distPath = function() {
+    return '_dist'
+};
+
+Styleguide.prototype.serve = function() {
+    return require('./lib/server')(this.config)
+};
+
+module.exports = Styleguide;

--- a/styleguide/layout.hbs
+++ b/styleguide/layout.hbs
@@ -49,10 +49,10 @@
             </div>
         </header>
         <div class="sg-menu">
-            <form class="sg-library-list">
+            <form class="sg-project-list">
                 <select onchange="window.location.href = $(this).val();">
                     {{#each availableLibraries}}
-                        <option value="{{library.urlPrefix}}"{{#if selected}} selected{{/if}}>{{library.name}}</option>
+                        <option value="{{project.urlPrefix}}"{{#if selected}} selected{{/if}}>{{project.name}}</option>
                     {{/each}}
                 </select>
             </form>

--- a/styleguide/layout.hbs
+++ b/styleguide/layout.hbs
@@ -49,14 +49,6 @@
             </div>
         </header>
         <div class="sg-menu">
-            <form class="sg-project-list">
-                <select onchange="window.location.href = $(this).val();">
-                    {{#each availableLibraries}}
-                        <option value="{{project.urlPrefix}}"{{#if selected}} selected{{/if}}>{{project.name}}</option>
-                    {{/each}}
-                </select>
-            </form>
-
             <ul class="sg-group-list">
                 {{#each groups}}
                     <li class="sg-group">

--- a/styleguide/styleguide.less
+++ b/styleguide/styleguide.less
@@ -82,14 +82,6 @@ a {
     width: @menu-width;
 }
 
-.sg-project-list {
-    margin-bottom: 24px;
-
-    select {
-        width: 100%;
-    }
-}
-
 .sg-group-list {
     list-style: none;
     margin: 0 0 12px 0;

--- a/styleguide/styleguide.less
+++ b/styleguide/styleguide.less
@@ -82,7 +82,7 @@ a {
     width: @menu-width;
 }
 
-.sg-library-list {
+.sg-project-list {
     margin-bottom: 24px;
 
     select {


### PR DESCRIPTION
Notable changes:
- The styleguide server can now be started as a node module anywhere in the project (see gulpfile in Base as an example)
- Multiple Library concept is no longer supported
- Library has been renamed to Project
- Project path and source path are now configurable
- Template path resolution is now relative to the location of the example JSON file (ie `"_template": "../../Foo"`)
- Template path extensions are now supported (and preferred) (ie `"_template": "Bar.hbs"`)
- JSON and Template files can be co-located
