### PR TITLE
BSP-3000: Add detail to the build error message for incorrect JSON syntax

### DIFF
--- a/js/task/lint.js
+++ b/js/task/lint.js
@@ -20,6 +20,7 @@ module.exports = (styleguide, gulp) => {
     json: () => {
       return gulp.src(path.join(styleguide.path.root(), 'styleguide/**/*.json'))
         .pipe(jsonlint())
+        .pipe(jsonlint.reporter())
         .pipe(jsonlint.failAfterError())
     },
 


### PR DESCRIPTION
* Adds a reporter to JSON linter pipeline

Before: 
![Before](https://cldup.com/5PyIPt0MEZ.png)

After: 
![After](https://cldup.com/ovgrOCEYRD.png)

This does not address the error message that is shown while watching. That will be addressed in a separate feature.