### PR TITLE
BSP-2956 Revert "Enables qualifyingElement linter"

### DIFF
--- a/js/task/.lesshintrc
+++ b/js/task/.lesshintrc
@@ -80,8 +80,7 @@
         "severity": "error"
     },
     "qualifyingElement": {
-        "enabled": true,
-        "severity": "error"
+        "enabled": false
     },
     "selectorNaming": {
         "enabled": true,


### PR DESCRIPTION
Reverting this due to conflict with modifier convention:

```
&[data-alignment='right']  { … }
```