### PR TITLE
BSP-3184: Remove _template / _view key requirement in Styleguide JSON and allow maps at any level.

### DIFF
--- a/codegen/src/main/java/com/psddev/styleguide/codegen/JsonFile.java
+++ b/codegen/src/main/java/com/psddev/styleguide/codegen/JsonFile.java
@@ -4,10 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import com.psddev.dari.util.IoUtils;
 
@@ -60,30 +57,6 @@ class JsonFile {
      * The JSON key pattern for providing documentation for a specific field within a view.
      */
     public static final String FIELD_NOTES_KEY_PATTERN = "_%sNotes";
-
-    /**
-     * The JSON key denoting an unstructured map value of key/value pairs for FE display related options.
-     */
-    public static final String DISPLAY_OPTIONS_KEY = "displayOptions";
-
-    /**
-     * The JSON key denoting an unstructured map value of key/value pairs that are placed on an HTML element as attributes.
-     */
-    public static final String EXTRA_ATTRIBUTES_KEY = "extraAttributes";
-
-    /**
-     * The JSON key denoting an unstructured map value of key/value pairs that are used to construct a free-form JSON object.
-     */
-    public static final String JSON_OBJECT_KEY = "jsonObject";
-
-    /**
-     * Special (non-underscore-prefixed) keys that allow their values to be
-     * unstructured non-view/template based maps.
-     */
-    public static final Set<String> JSON_MAP_KEYS = new HashSet<>(Arrays.asList(
-            DISPLAY_OPTIONS_KEY,
-            EXTRA_ATTRIBUTES_KEY,
-            JSON_OBJECT_KEY));
 
     private JsonDirectory baseDirectory;
 

--- a/codegen/src/main/java/com/psddev/styleguide/codegen/ViewClassSourceGenerator.java
+++ b/codegen/src/main/java/com/psddev/styleguide/codegen/ViewClassSourceGenerator.java
@@ -421,7 +421,7 @@ class ViewClassSourceGenerator {
 
         methodJavadocs.addSampleValuesList(fieldDef, 10);
 
-        boolean isDefaulted = context.isGenerateDefaultMethods();
+        boolean isDefaulted = context.isGenerateDefaultMethods() || fieldDef.getEffectiveType() == JsonMap.class;
 
         // if it's a default interface method just make the body return null;
         String methodBody = !isDefaulted ? ";" : (" {\n"


### PR DESCRIPTION
The special "map" keys are also no longer special.