### PR TITLE
BSP-3517: Fix incorrect sticking behavior of the leftnav

### DIFF
--- a/styleguide/main.hbs
+++ b/styleguide/main.hbs
@@ -36,6 +36,7 @@
                         {{/if}}
                         initCallback: function(iframe) {
                             $(iframe).contents().find('html', 'body').css('height', 'auto');
+                            $(document.body).trigger('sticky_kit:recalc');
                         }
                     });
                 });

--- a/styleguide/main.hbs
+++ b/styleguide/main.hbs
@@ -158,13 +158,15 @@
 
                                     <iframe
                                         style="height: {{device.height}}px; width: {{device.width}}px;"
-                                        src="{{../../url}}?device=true&amp;seed={{../../../seed}}{{#if ../../../selectedStyleSheet}}&amp;ss={{../../../selectedStyleSheet.idx}}{{/if}}">
+                                        src="{{../../url}}?device=true&amp;seed={{../../../seed}}{{#if ../../../selectedStyleSheet}}&amp;ss={{../../../selectedStyleSheet.idx}}{{/if}}"
+                                        onload="$(document.body).trigger('sticky_kit:recalc')">
                                     </iframe>
                                 </div>
                             {{/each}}
 
                         {{else}}
-                            <iframe src="{{url}}?seed={{../seed}}{{#if ../selectedStyleSheet}}&amp;ss={{../selectedStyleSheet.idx}}{{/if}}"></iframe>
+                            <iframe src="{{url}}?seed={{../seed}}{{#if ../selectedStyleSheet}}&amp;ss={{../selectedStyleSheet.idx}}{{/if}}"
+                            onload="$(document.body).trigger('sticky_kit:recalc')"></iframe>
                         {{/with}}
                     </div>
                 </div>


### PR DESCRIPTION
 This is fixed by triggering the stickykit plugin to recalculate after each example frame has loaded.